### PR TITLE
Update Playwright container image to v1.61.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.60.0-jammy
+      image: mcr.microsoft.com/playwright:v1.61.1-jammy
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
Updates the Playwright container image used in the CI workflow from v1.60.0 to v1.61.1 to leverage the latest bug fixes and improvements.

## Changes
- Updated `.github/workflows/ci.yml` to use `mcr.microsoft.com/playwright:v1.61.1-jammy` instead of v1.60.0

## Details
This is a patch version update that brings the latest Playwright improvements to the CI pipeline, ensuring tests run with the most recent stable version of Playwright.

https://claude.ai/code/session_01BrbDAqWqsQHh5FEH3yz9wq