### PR TITLE
chore: change default vite dev server port to 3377

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     env:
       TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
       TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-      PUBLIC_BASE_URL: http://localhost:5173
+      PUBLIC_BASE_URL: http://localhost:3377
       HOME: /root
     name: Test Playwright
     timeout-minutes: 60

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To run the app locally, follow these steps:
    - Configure environment variables in a `.env` file. These will be automatically available via `$env/static/private`.
 
 5. **Preview the app**:
-   - Open [http://localhost:5173](http://localhost:5173) in your browser.
+   - Open [http://localhost:3377](http://localhost:3377) in your browser.
 
 ## Deploying
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ const config: PlaywrightTestConfig = {
 	webServer: {
 		command: 'npm run dev',
 		reuseExistingServer: true,
-		port: 5173,
+		port: 3377,
 		stdout: 'pipe',
 		stderr: 'pipe'
 	},
@@ -12,7 +12,7 @@ const config: PlaywrightTestConfig = {
 	workers: 1,
 	testMatch: /(.+\.)?(test|spec)\.[jt]s/,
 	use: {
-		baseURL: 'http://localhost:5173',
+		baseURL: 'http://localhost:3377',
 		trace: 'retain-on-failure',
 		screenshot: 'only-on-failure',
 		video: 'retain-on-failure'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,9 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
+	server: {
+		port: 3377
+	},
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}'],
 		clearMocks: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local preview instructions to use port 3377.

* **Configuration**
  * Standardized the development server and end-to-end test environment to run at `http://localhost:3377`.
  * Updated automated browser tests to target the new local server address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->