### PR TITLE
feat: instant-load from local cache with background sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Agent Instructions
+
+Project-specific guidance for AI coding agents. See `.claude/CLAUDE.md` for the full technical requirements and code style.
+
+## Before committing
+
+- Run the `caveman-review` skill on your changes and address its findings **before committing**.
+- Run `npm run check` and `npm run lint`, and fix any issues (use `npm run format` for formatting).

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 				"@tiptap/extension-placeholder": "3.28.0",
 				"@tiptap/pm": "3.28.0",
 				"@tiptap/starter-kit": "3.28.0",
+				"idb-keyval": "^6.3.0",
 				"jose": "6.2.3",
 				"nanoid": "6.0.0",
 				"neverthrow": "8.2.0",
@@ -4678,6 +4679,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/typicode"
 			}
+		},
+		"node_modules/idb-keyval": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.3.0.tgz",
+			"integrity": "sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"@tiptap/extension-placeholder": "3.28.0",
 		"@tiptap/pm": "3.28.0",
 		"@tiptap/starter-kit": "3.28.0",
+		"idb-keyval": "^6.3.0",
 		"jose": "6.2.3",
 		"nanoid": "6.0.0",
 		"neverthrow": "8.2.0",

--- a/src/lib/browserFetch.ts
+++ b/src/lib/browserFetch.ts
@@ -32,6 +32,17 @@ export function fail(message: string): Fail {
 const maxRetries = 3;
 const retryDelay = 200;
 let queueTail: Promise<unknown> = Promise.resolve();
+let pending = 0;
+
+export function isWriteQueueIdle(): boolean {
+	return pending === 0;
+}
+
+export async function whenWriteQueueIdle(): Promise<void> {
+	while (pending > 0) {
+		await queueTail.catch(() => undefined);
+	}
+}
 
 async function fetchWithRetry(func: () => Promise<Response>, retryCount = 0): Promise<Response> {
 	try {
@@ -62,28 +73,33 @@ export async function tryFetch<T>(
 	const shouldParse = options?.shouldParse ?? false;
 	const clearQueueOnError = options?.clearQueueOnError ?? false;
 
-	const thisRequest = queueTail.then(() =>
-		fetchWithRetry(() =>
-			fetch(input, {
-				...init,
-				headers: {
-					'Content-Type': 'application/json',
-					...init?.headers
+	pending++;
+	const thisRequest = queueTail
+		.then(() =>
+			fetchWithRetry(() =>
+				fetch(input, {
+					...init,
+					headers: {
+						'Content-Type': 'application/json',
+						...init?.headers
+					}
+				})
+			).then(async (resp) => {
+				if (!resp.ok) {
+					const rawText = await resp.text();
+					return fail(rawText);
+				}
+
+				if (shouldParse) {
+					return resp.json().then((json) => success(json));
+				} else {
+					return success(resp);
 				}
 			})
-		).then(async (resp) => {
-			if (!resp.ok) {
-				const rawText = await resp.text();
-				return fail(rawText);
-			}
-
-			if (shouldParse) {
-				return resp.json().then((json) => success(json));
-			} else {
-				return success(resp);
-			}
-		})
-	);
+		)
+		.finally(() => {
+			pending--;
+		});
 
 	if (clearQueueOnError) {
 		queueTail = thisRequest.catch(() => {

--- a/src/lib/browserFetch.ts
+++ b/src/lib/browserFetch.ts
@@ -31,6 +31,7 @@ export function fail(message: string): Fail {
 
 const maxRetries = 3;
 const retryDelay = 200;
+const defaultIdleTimeout = 8000;
 let queueTail: Promise<unknown> = Promise.resolve();
 let pending = 0;
 
@@ -38,9 +39,21 @@ export function isWriteQueueIdle(): boolean {
 	return pending === 0;
 }
 
-export async function whenWriteQueueIdle(): Promise<void> {
+// Resolves when the write queue drains, or after `timeoutMs` so a hung request
+// (fetch has no built-in timeout) can never block the caller indefinitely.
+export async function whenWriteQueueIdle(timeoutMs = defaultIdleTimeout): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
 	while (pending > 0) {
-		await queueTail.catch(() => undefined);
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) {
+			return;
+		}
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const timeout = new Promise<void>((resolve) => {
+			timer = setTimeout(resolve, remaining);
+		});
+		await Promise.race([queueTail.catch(() => undefined), timeout]);
+		clearTimeout(timer);
 	}
 }
 

--- a/src/lib/state/boardState.svelte.ts
+++ b/src/lib/state/boardState.svelte.ts
@@ -35,6 +35,18 @@ export class BoardState {
 		this.friends = friends;
 	}
 
+	hydrate(snapshot: {
+		boardId: string;
+		noteOrder: string[];
+		notes: NoteOrdered[];
+		friends: Friend[];
+	}) {
+		this.boardId = snapshot.boardId;
+		this.noteOrder = snapshot.noteOrder;
+		this.notes = snapshot.notes;
+		this.friends = snapshot.friends;
+	}
+
 	reset() {
 		this.boardId = '';
 		this.noteOrder = [];

--- a/src/lib/state/friendsState.svelte.ts
+++ b/src/lib/state/friendsState.svelte.ts
@@ -27,6 +27,16 @@ export class FriendsState {
 		this.pendingReceivedInvites = pendingReceivedInvites;
 	}
 
+	hydrateState(snapshot: {
+		friends: Friend[];
+		pendingSentInvites: UserInvite[];
+		pendingReceivedInvites: UserInviteWithUserProps[];
+	}) {
+		this.friends = snapshot.friends;
+		this.pendingSentInvites = snapshot.pendingSentInvites;
+		this.pendingReceivedInvites = snapshot.pendingReceivedInvites;
+	}
+
 	cancelInvite(inviteId: string): [number, UserInvite] {
 		const [index, invite, newArray] = removeValueWithId(this.pendingSentInvites, inviteId);
 		this.pendingSentInvites = newArray;

--- a/src/lib/state/localCache.ts
+++ b/src/lib/state/localCache.ts
@@ -1,0 +1,88 @@
+import { get, set, del } from 'idb-keyval';
+import { browser } from '$app/environment';
+
+import type { NoteOrdered, Friend, UserInvite, UserInviteWithUserProps } from '$lib/types';
+
+const snapshotVersion = 1;
+
+export interface BoardSnapshot {
+	version: number;
+	boardId: string;
+	noteOrder: string[];
+	notes: NoteOrdered[];
+	friends: Friend[];
+}
+
+export interface FriendsSnapshot {
+	version: number;
+	friends: Friend[];
+	pendingSentInvites: UserInvite[];
+	pendingReceivedInvites: UserInviteWithUserProps[];
+}
+
+function boardKey(userId: string) {
+	return `board:${userId}`;
+}
+
+function friendsKey(userId: string) {
+	return `friends:${userId}`;
+}
+
+async function readSnapshot<T extends { version: number }>(key: string): Promise<T | undefined> {
+	if (!browser) {
+		return undefined;
+	}
+	try {
+		const snapshot = await get<T>(key);
+		if (!snapshot || snapshot.version !== snapshotVersion) {
+			return undefined;
+		}
+		return snapshot;
+	} catch {
+		return undefined;
+	}
+}
+
+async function writeSnapshot(key: string, snapshot: unknown): Promise<void> {
+	if (!browser) {
+		return;
+	}
+	try {
+		await set(key, snapshot);
+	} catch {
+		// IndexedDB may be unavailable (private mode, quota); degrade to no cache.
+	}
+}
+
+export function getBoardSnapshot(userId: string): Promise<BoardSnapshot | undefined> {
+	return readSnapshot<BoardSnapshot>(boardKey(userId));
+}
+
+export function setBoardSnapshot(
+	userId: string,
+	snapshot: Omit<BoardSnapshot, 'version'>
+): Promise<void> {
+	return writeSnapshot(boardKey(userId), { version: snapshotVersion, ...snapshot });
+}
+
+export function getFriendsSnapshot(userId: string): Promise<FriendsSnapshot | undefined> {
+	return readSnapshot<FriendsSnapshot>(friendsKey(userId));
+}
+
+export function setFriendsSnapshot(
+	userId: string,
+	snapshot: Omit<FriendsSnapshot, 'version'>
+): Promise<void> {
+	return writeSnapshot(friendsKey(userId), { version: snapshotVersion, ...snapshot });
+}
+
+export async function clearSnapshots(userId: string): Promise<void> {
+	if (!browser) {
+		return;
+	}
+	try {
+		await Promise.all([del(boardKey(userId)), del(friendsKey(userId))]);
+	} catch {
+		// Nothing to clean up if IndexedDB is unavailable.
+	}
+}

--- a/src/routes/my/+layout.svelte
+++ b/src/routes/my/+layout.svelte
@@ -62,10 +62,12 @@
 			friendsState.setState(friends, pendingSentInvites, pendingReceivedInvites);
 			return;
 		}
+		throw new Error('Could not reconcile with server: write queue never became idle');
 	}
 
 	onMount(async () => {
-		let hydratedFromCache = false;
+		let boardHydrated = false;
+		let friendsHydrated = false;
 
 		if (userId) {
 			const [boardSnapshot, friendsSnapshot] = await Promise.all([
@@ -75,23 +77,24 @@
 
 			if (boardSnapshot) {
 				boardState.hydrate(boardSnapshot);
-				hydratedFromCache = true;
+				boardHydrated = true;
 			}
 			if (friendsSnapshot) {
 				friendsState.hydrateState(friendsSnapshot);
+				friendsHydrated = true;
 			}
 		}
 
 		// With a cached snapshot we can paint immediately and refresh silently;
 		// otherwise keep the skeleton until the first server response arrives.
-		boardState.setLoading(!hydratedFromCache);
-		friendsState.setLoading(!hydratedFromCache);
+		boardState.setLoading(!boardHydrated);
+		friendsState.setLoading(!friendsHydrated);
 
 		try {
 			await refreshFromServer();
 		} catch (err) {
 			console.error('Error loading data:', err);
-			if (!hydratedFromCache) {
+			if (!boardHydrated && !friendsHydrated) {
 				toastMessages.addMessage({
 					type: 'error',
 					message: 'There was a problem loading your data'

--- a/src/routes/my/+layout.svelte
+++ b/src/routes/my/+layout.svelte
@@ -6,11 +6,20 @@
 	import Note from '$components/Note.svelte';
 	import Search from '$components/Search.svelte';
 	import logo from '$lib/images/notes-main.png';
-	import { tryFetch } from '$lib/browserFetch';
+	import { tryFetch, isWriteQueueIdle, whenWriteQueueIdle } from '$lib/browserFetch';
 	import { getBoardState } from '$lib/state/boardState.svelte';
 	import { getToastMessages } from '$lib/state/toastMessages.svelte';
 	import { setFriendsState, getFriendsState } from '$lib/state/friendsState.svelte';
 	import { getUserState } from '$lib/state/userState.svelte';
+	import {
+		getBoardSnapshot,
+		setBoardSnapshot,
+		getFriendsSnapshot,
+		setFriendsSnapshot
+	} from '$lib/state/localCache';
+
+	const persistDebounceMs = 400;
+	const maxReconcileAttempts = 3;
 
 	let { children, data } = $props();
 
@@ -22,33 +31,108 @@
 	const friendsState = getFriendsState();
 	const toastMessages = getToastMessages();
 	const userState = getUserState();
+	const userId = data.userData?.id ?? '';
 
 	userState.setName(data.userData?.name ?? '');
 
-	onMount(async () => {
-		boardState.setLoading(true);
-		friendsState.setLoading(true);
+	async function refreshFromServer() {
+		// Server is the source of truth, but only apply it when the optimistic
+		// write queue is idle so in-flight local changes are not clobbered. If a
+		// write races the fetch, retry so the re-fetch reflects the synced change.
+		for (let attempt = 0; attempt < maxReconcileAttempts; attempt++) {
+			await whenWriteQueueIdle();
 
-		const [boardResp, friendsResp] = await Promise.all([
-			fetch('/api/user/board'),
-			fetch('/api/friends')
-		]);
-
-		try {
+			const [boardResp, friendsResp] = await Promise.all([
+				fetch('/api/user/board'),
+				fetch('/api/friends')
+			]);
+			if (!boardResp.ok || !friendsResp.ok) {
+				throw new Error(
+					`Failed to load data: board ${boardResp.status}, friends ${friendsResp.status}`
+				);
+			}
 			const { board, sharedNotes, sharedNoteOwners } = await boardResp.json();
 			const { friends, pendingSentInvites, pendingReceivedInvites } = await friendsResp.json();
+
+			if (!isWriteQueueIdle()) {
+				continue;
+			}
+
 			boardState.setBoard(board, friends, sharedNotes, sharedNoteOwners);
 			friendsState.setState(friends, pendingSentInvites, pendingReceivedInvites);
+			return;
+		}
+	}
+
+	onMount(async () => {
+		let hydratedFromCache = false;
+
+		if (userId) {
+			const [boardSnapshot, friendsSnapshot] = await Promise.all([
+				getBoardSnapshot(userId),
+				getFriendsSnapshot(userId)
+			]);
+
+			if (boardSnapshot) {
+				boardState.hydrate(boardSnapshot);
+				hydratedFromCache = true;
+			}
+			if (friendsSnapshot) {
+				friendsState.hydrateState(friendsSnapshot);
+			}
+		}
+
+		// With a cached snapshot we can paint immediately and refresh silently;
+		// otherwise keep the skeleton until the first server response arrives.
+		boardState.setLoading(!hydratedFromCache);
+		friendsState.setLoading(!hydratedFromCache);
+
+		try {
+			await refreshFromServer();
 		} catch (err) {
 			console.error('Error loading data:', err);
-			toastMessages.addMessage({
-				type: 'error',
-				message: 'There was a problem loading your data'
-			});
+			if (!hydratedFromCache) {
+				toastMessages.addMessage({
+					type: 'error',
+					message: 'There was a problem loading your data'
+				});
+			}
 		} finally {
 			boardState.setLoading(false);
 			friendsState.setLoading(false);
 		}
+	});
+
+	// Persist state to the local cache (debounced) so the next load paints instantly.
+	$effect(() => {
+		const snapshot = $state.snapshot({
+			boardId: boardState.boardId,
+			noteOrder: boardState.noteOrder,
+			notes: boardState.notes,
+			friends: boardState.friends
+		});
+
+		if (!userId || boardState.loading) {
+			return;
+		}
+
+		const timer = setTimeout(() => setBoardSnapshot(userId, snapshot), persistDebounceMs);
+		return () => clearTimeout(timer);
+	});
+
+	$effect(() => {
+		const snapshot = $state.snapshot({
+			friends: friendsState.friends,
+			pendingSentInvites: friendsState.pendingSentInvites,
+			pendingReceivedInvites: friendsState.pendingReceivedInvites
+		});
+
+		if (!userId || friendsState.loading) {
+			return;
+		}
+
+		const timer = setTimeout(() => setFriendsSnapshot(userId, snapshot), persistDebounceMs);
+		return () => clearTimeout(timer);
 	});
 
 	async function handleCreateNote() {


### PR DESCRIPTION
## What & why

The app *felt* local-first but wasn't: state lived entirely in-memory and every full page load blocked first paint on `fetch('/api/user/board')` + `fetch('/api/friends')`, showing a skeleton until the network responded. It was really **optimistic updates**, not local-first.

This adds a durable **IndexedDB read-cache** so the `/my` board and friends paint **instantly from a locally-stored snapshot**, then **reconcile from the server in the background** — the "load everything first, sync in the background" experience.

This is the incremental path (not a local-first framework rewrite). The app already had the hard parts — client-generated IDs, optimistic mutations, and a serialized retrying write queue — so the only missing piece was durable local persistence.

## Changes

- **`src/lib/state/localCache.ts` (new)** — SSR-safe, error-tolerant per-user snapshot `get`/`set`/`clear` over [`idb-keyval`](https://www.npmjs.com/package/idb-keyval). Keyed `board:<userId>` / `friends:<userId>`; a version mismatch or any IndexedDB failure (private mode/quota) degrades to a cache miss.
- **`src/lib/browserFetch.ts`** — expose `isWriteQueueIdle()` / `whenWriteQueueIdle()` (purely observational; queue mechanics unchanged) so background reconcile can avoid clobbering in-flight optimistic writes.
- **`BoardState.hydrate` / `FriendsState.hydrateState`** — rehydrate directly from a cached snapshot without re-running the API→state transform.
- **`src/routes/my/+layout.svelte`** — hydrate-first paint from cache, then `refreshFromServer()`; debounced `$effect` persistence via `$state.snapshot` (skips while `loading`, so an empty pre-hydration store never overwrites a good snapshot).
- **`AGENTS.md` (new)** — run `caveman-review` before committing.

## Correctness: no clobbering optimistic writes

`refreshFromServer` applies server data **only when the write queue is idle**. If an optimistic write races the background fetch, it retries (bounded to 3) so the re-fetch reflects the synced change — server-wins-when-idle. Shared-note/editor changes made by other users are exactly the case where the server *should* overwrite local, and by then the queue is idle so it's safe.

## Safe rollout

First-ever load (cache miss) keeps today's exact skeleton-then-data behaviour, so every user's first load post-deploy is unchanged.

## Verification

- `npm run check` — 0 errors; `npm run lint` — clean; `npm run test:unit` — 58 passing; `npm run build` — succeeds.
- Recommended manual check: DevTools → Network → Slow 3G, reload → notes paint immediately from cache (no skeleton), then silently refresh once the throttled GET resolves. Clear IndexedDB (`keyval-store`) to confirm the cache-miss path still shows the skeleton.

## Deferred follow-ups (out of scope)

- **Durable offline write queue** — persist the in-memory `tryFetch` queue so unsent writes survive a reload/offline and replay.
- **Offline app shell** — a service worker so the app opens with no network at all.
- **Logout cache-clear** — `clearSnapshots` is implemented and exported; wiring it into the Auth0 logout redirect is deferred (per-user keys already prevent cross-user display). Note: `boardState.reset()` is the landing-page demo reset, **not** logout, so cache-clear was intentionally not wired there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local caching for board data, friends, and invitations to improve startup speed and preserve recent data between sessions.
  * Added background synchronization to refresh cached data when online changes are ready.
  * Added automatic state restoration from locally saved snapshots.

* **Bug Fixes**
  * Improved loading behavior by displaying cached content while fresh data is retrieved.
  * Reduced the risk of overwriting recent changes during synchronization.

* **Documentation**
  * Added project guidance and a pre-commit checklist for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->