### PR TITLE
feat: add bold/italic/underline formatting toolbar to note editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"@tiptap/core": "3.28.0",
 		"@tiptap/extension-hard-break": "3.28.0",
 		"@tiptap/extension-placeholder": "3.28.0",
+		"@tiptap/extension-underline": "3.28.0",
 		"@tiptap/pm": "3.28.0",
 		"@tiptap/starter-kit": "3.28.0",
 		"idb-keyval": "6.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tiptap/extension-placeholder':
         specifier: 3.28.0
         version: 3.28.0(@tiptap/extensions@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))
+      '@tiptap/extension-underline':
+        specifier: 3.28.0
+        version: 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
       '@tiptap/pm':
         specifier: 3.28.0
         version: 3.28.0

--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -2,11 +2,12 @@
 	import type { Snippet } from 'svelte';
 	import { createTooltip, melt } from '@melt-ui/svelte';
 
-	import { type Variant, buildButtonClass } from '$lib/button';
+	import { type Size, type Variant, buildButtonClass } from '$lib/button';
 
 	type Props = {
 		children: Snippet<[]>;
 		variant?: Variant;
+		size?: Size;
 		rounded?: boolean;
 		type?: 'button' | 'submit' | 'reset';
 		label?: string;
@@ -20,6 +21,7 @@
 	const {
 		children,
 		variant = 'primary',
+		size = 'md',
 		rounded,
 		type,
 		label = '',
@@ -30,7 +32,9 @@
 		onclick
 	}: Props = $props();
 
-	const buttonClass = $derived(buildButtonClass(variant, rounded, loading || disabled, active));
+	const buttonClass = $derived(
+		buildButtonClass(variant, rounded, loading || disabled, active, size)
+	);
 
 	const {
 		elements: { trigger, content, arrow },

--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -12,6 +12,7 @@
 		label?: string;
 		loading?: boolean;
 		disabled?: boolean;
+		active?: boolean;
 		tooltip?: string;
 		onclick?: () => void;
 	};
@@ -24,11 +25,12 @@
 		label = '',
 		loading = false,
 		disabled = false,
+		active = false,
 		tooltip,
 		onclick
 	}: Props = $props();
 
-	const buttonClass = $derived(buildButtonClass(variant, rounded, loading || disabled));
+	const buttonClass = $derived(buildButtonClass(variant, rounded, loading || disabled, active));
 
 	const {
 		elements: { trigger, content, arrow },

--- a/src/components/HtmlEditor.svelte
+++ b/src/components/HtmlEditor.svelte
@@ -4,14 +4,16 @@
 	import StarterKit from '@tiptap/starter-kit';
 	import HardBreak from '@tiptap/extension-hard-break';
 	import Placeholder from '@tiptap/extension-placeholder';
+	import Underline from '@tiptap/extension-underline';
 
 	type Props = {
 		id: string;
 		initialContent: string;
 		onupdate(html: string, plaintext: string): void;
+		oneditorcreate?(editor: Editor): void;
 	};
 
-	let { initialContent, id, onupdate }: Props = $props();
+	let { initialContent, id, onupdate, oneditorcreate }: Props = $props();
 	let element: HTMLDivElement;
 	let editor: Editor;
 
@@ -56,7 +58,8 @@
 				ShiftEnterParagraph,
 				Placeholder.configure({
 					placeholder: 'Write a note ...'
-				})
+				}),
+				Underline
 			],
 			content: initialContent,
 
@@ -64,6 +67,8 @@
 				onupdate(editor.getHTML(), editor.getText());
 			}
 		});
+
+		oneditorcreate?.(editor);
 	});
 
 	onDestroy(() => {

--- a/src/components/NoteEditor.svelte
+++ b/src/components/NoteEditor.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import type { Editor } from '@tiptap/core';
+
 	import { type Colour } from '$lib/colours';
 	import type { FriendSelection, NoteOrdered, ToggleFriendShare } from '$lib/types';
 	import { X, Trash2 } from '@lucide/svelte';
@@ -8,6 +10,7 @@
 	import Dialog from './Dialog.svelte';
 	import Share from './Share.svelte';
 	import HtmlEditor from './HtmlEditor.svelte';
+	import Toolbar from './Toolbar.svelte';
 	import UserAvatar from './UserAvatar.svelte';
 
 	type Props = {
@@ -35,6 +38,7 @@
 	let noteText: string = $state(note.text);
 	let noteTextPlain: string = $state(note.textPlain);
 	let noteTitle: string | null = $state(note.title);
+	let editor: Editor | null = $state(null);
 
 	let hasUnsavedChanges = $derived(
 		noteText !== note.text || noteTextPlain !== note.textPlain || noteTitle !== note.title
@@ -139,7 +143,13 @@
 			placeholder="Title"
 			class="w-full bg-transparent px-4 py-2 text-xl font-bold focus-visible:outline-hidden"
 		/>
-		<HtmlEditor id="note-editor" initialContent={noteText} onupdate={handleContentUpdate} />
+		<Toolbar {editor} />
+		<HtmlEditor
+			id="note-editor"
+			initialContent={noteText}
+			onupdate={handleContentUpdate}
+			oneditorcreate={(e) => (editor = e)}
+		/>
 	{/snippet}
 
 	{#snippet footer()}

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import type { Editor } from '@tiptap/core';
+	import { Bold, Italic, Underline } from '@lucide/svelte';
+
+	import Button from './Button.svelte';
+
+	type Props = {
+		editor: Editor | null;
+	};
+
+	type MarkName = 'bold' | 'italic' | 'underline';
+
+	let { editor }: Props = $props();
+
+	const iconSize = 20;
+
+	const toolbarItemsValue = [
+		{
+			mark: 'bold' as MarkName,
+			label: 'Bold',
+			Icon: Bold,
+			toggle: (e: Editor) => e.chain().focus().toggleBold().run()
+		},
+		{
+			mark: 'italic' as MarkName,
+			label: 'Italic',
+			Icon: Italic,
+			toggle: (e: Editor) => e.chain().focus().toggleItalic().run()
+		},
+		{
+			mark: 'underline' as MarkName,
+			label: 'Underline',
+			Icon: Underline,
+			toggle: (e: Editor) => e.chain().focus().toggleUnderline().run()
+		}
+	];
+
+	let transactionCount = $state(0);
+
+	$effect(() => {
+		if (!editor) return;
+
+		const handleTransaction = () => {
+			transactionCount += 1;
+		};
+
+		editor.on('transaction', handleTransaction);
+		return () => editor.off('transaction', handleTransaction);
+	});
+
+	let activeMarks = $derived.by(() => {
+		// Reads transactionCount to register it as a dependency, forcing recompute on every TipTap transaction
+		const isTransactionTracked = transactionCount >= 0;
+		return {
+			bold: isTransactionTracked && (editor?.isActive('bold') ?? false),
+			italic: isTransactionTracked && (editor?.isActive('italic') ?? false),
+			underline: isTransactionTracked && (editor?.isActive('underline') ?? false)
+		};
+	});
+</script>
+
+{#if editor}
+	<div
+		class="dark:border-dark-border flex gap-1 border-b px-2 py-1"
+		role="toolbar"
+		aria-label="Text formatting"
+	>
+		{#each toolbarItemsValue as { mark, label, Icon, toggle }}
+			<Button variant="ghost" {label} active={activeMarks[mark]} onclick={() => toggle(editor)}>
+				<Icon size={iconSize} />
+			</Button>
+		{/each}
+	</div>
+{/if}

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -12,7 +12,7 @@
 
 	let { editor }: Props = $props();
 
-	const iconSize = 20;
+	const iconSize = 16;
 
 	const toolbarItemsValue = [
 		{
@@ -61,12 +61,18 @@
 
 {#if editor}
 	<div
-		class="dark:border-dark-border flex gap-1 border-b px-2 py-1"
+		class="dark:border-dark-border flex gap-2 border-b px-2 pt-2 pb-4"
 		role="toolbar"
 		aria-label="Text formatting"
 	>
 		{#each toolbarItemsValue as { mark, label, Icon, toggle }}
-			<Button variant="ghost" {label} active={activeMarks[mark]} onclick={() => toggle(editor)}>
+			<Button
+				variant="ghost"
+				size="sm"
+				{label}
+				active={activeMarks[mark]}
+				onclick={() => toggle(editor)}
+			>
 				<Icon size={iconSize} />
 			</Button>
 		{/each}

--- a/src/lib/button.ts
+++ b/src/lib/button.ts
@@ -8,8 +8,14 @@ const variantClasses = {
 	ghost: 'dark:hover:darkHover hover:ring-2'
 } as const;
 
-export const buildButtonClass = (variant: Variant, round = false, loading = false) => {
+export const buildButtonClass = (
+	variant: Variant,
+	round = false,
+	loading = false,
+	active = false
+) => {
 	const roundedClass = round ? 'rounded-full' : 'rounded-xl';
 	const loadingClass = loading ? 'opacity-50 pointer-events-none' : '';
-	return `${loadingClass} ${baseClasses} ${variantClasses[variant]} ${roundedClass}`;
+	const activeClass = active ? 'ring-2 ring-primary bg-primary/10' : '';
+	return `${loadingClass} ${baseClasses} ${variantClasses[variant]} ${roundedClass} ${activeClass}`;
 };

--- a/src/lib/button.ts
+++ b/src/lib/button.ts
@@ -1,6 +1,12 @@
 export type Variant = 'primary' | 'secondary' | 'ghost';
+export type Size = 'sm' | 'md';
 
-const baseClasses = `flex min-h-11 min-w-[44px] items-center justify-center gap-2 px-4 py-2 transition-all duration-150 hover:scale-105 focus:outline-hidden`;
+const baseClasses = `flex items-center justify-center gap-2 transition-all duration-150 hover:scale-105 focus:outline-hidden`;
+
+const sizeClasses = {
+	sm: 'min-h-8 min-w-8 p-1.5',
+	md: 'min-h-11 min-w-[44px] px-4 py-2'
+} as const;
 
 const variantClasses = {
 	primary: 'bg-primary hover:bg-primary/90 text-white border-none',
@@ -12,10 +18,11 @@ export const buildButtonClass = (
 	variant: Variant,
 	round = false,
 	loading = false,
-	active = false
+	active = false,
+	size: Size = 'md'
 ) => {
 	const roundedClass = round ? 'rounded-full' : 'rounded-xl';
 	const loadingClass = loading ? 'opacity-50 pointer-events-none' : '';
 	const activeClass = active ? 'ring-2 ring-primary bg-primary/10' : '';
-	return `${loadingClass} ${baseClasses} ${variantClasses[variant]} ${roundedClass} ${activeClass}`;
+	return `${loadingClass} ${baseClasses} ${sizeClasses[size]} ${variantClasses[variant]} ${roundedClass} ${activeClass}`;
 };


### PR DESCRIPTION
## Summary
- Adds a fixed formatting toolbar (Bold/Italic/Underline) above the note editor content in `NoteEditor.svelte`, using TipTap's existing Bold/Italic marks plus the new `@tiptap/extension-underline`.
- New `Toolbar.svelte` component uses `@lucide/svelte`'s `Bold`/`Italic`/`Underline` icons and reflects active-mark state reactively by subscribing to TipTap's `transaction` event (fires on both content and selection changes).
- `HtmlEditor.svelte` gains an `oneditorcreate` callback prop (mirrors the existing `onupdate` convention) so the parent can hold a live reference to the TipTap `Editor` instance.
- `Button`/`buildButtonClass` (`src/lib/button.ts`) gain a small, reusable `active` toggle-state concept (`ring-2 ring-primary bg-primary/10`) for this and any future toggle button.
- MVP scope: bold/italic/underline only, fixed toolbar placement (not a floating bubble menu) — simplest, no new positioning dependency, touch-friendly on this mobile-first app.

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm lint` (prettier + eslint) — clean
- [x] Verified live on an authenticated note (real Auth0 login via test credentials): selected text, toggled Bold/Italic/Underline — marks apply correctly, toolbar buttons show the active ring/tint, state updates via the `transaction` subscription (confirmed via DOM class inspection toggling true/false), and the existing "unsaved changes" confirm-on-close dialog still works.
- [ ] `tests/noteManagement.test.ts` (Playwright) not run against this branch yet — recommend running in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1tdpzRboY4mSzwsP5uG9m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bold, Italic, and Underline formatting controls to the note editor.
  * Added underline formatting support.
  * Toolbar buttons now indicate active formatting and support multiple sizes.
  * Added an editor initialization callback for integrations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->