### PR TITLE
Migrate Button.svelte's tooltip to bits-ui

### DIFF
--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
-	import { createTooltip, melt } from '@melt-ui/svelte';
+	import { Tooltip } from 'bits-ui';
 
 	import { type Size, type Variant, buildButtonClass } from '$lib/button';
 
@@ -35,51 +35,49 @@
 	const buttonClass = $derived(
 		buildButtonClass(variant, rounded, loading || disabled, active, size)
 	);
-
-	const {
-		elements: { trigger, content, arrow },
-		states: { open }
-	} = createTooltip({
-		positioning: {
-			placement: 'top'
-		},
-		openDelay: 0,
-		closeDelay: 0,
-		closeOnPointerDown: false,
-		forceVisible: true
-	});
 </script>
 
-<button
-	{type}
-	class={buttonClass}
-	{onclick}
-	aria-label={label}
-	disabled={loading || disabled}
-	use:melt={$trigger}
->
-	{#if loading}
-		<svg
-			class="mr-3 -ml-1 h-5 w-5 animate-spin dark:text-white"
-			xmlns="http://www.w3.org/2000/svg"
-			fill="none"
-			viewBox="0 0 24 24"
-		>
-			<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
-			></circle>
-			<path
-				class="opacity-75"
-				fill="currentColor"
-				d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-			></path>
-		</svg>
-	{/if}
-	{@render children()}
-</button>
+{#snippet buttonElement(triggerProps?: Record<string, unknown>)}
+	<button
+		{...triggerProps}
+		{type}
+		class={buttonClass}
+		{onclick}
+		aria-label={label}
+		disabled={loading || disabled}
+	>
+		{#if loading}
+			<svg
+				class="mr-3 -ml-1 h-5 w-5 animate-spin dark:text-white"
+				xmlns="http://www.w3.org/2000/svg"
+				fill="none"
+				viewBox="0 0 24 24"
+			>
+				<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
+				></circle>
+				<path
+					class="opacity-75"
+					fill="currentColor"
+					d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+				></path>
+			</svg>
+		{/if}
+		{@render children()}
+	</button>
+{/snippet}
 
-{#if $open && tooltip}
-	<div use:melt={$content} class="z-toaster rounded-lg bg-black shadow-sm">
-		<div use:melt={$arrow}></div>
-		<p class="p-4 text-sm text-white">{tooltip}</p>
-	</div>
+{#if tooltip}
+	<Tooltip.Root delayDuration={0} disableCloseOnTriggerClick>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				{@render buttonElement(props)}
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content sideOffset={8} side="top" class="z-toaster rounded-lg bg-black shadow-sm">
+			<Tooltip.Arrow />
+			<p class="p-4 text-sm text-white">{tooltip}</p>
+		</Tooltip.Content>
+	</Tooltip.Root>
+{:else}
+	{@render buttonElement()}
 {/if}


### PR DESCRIPTION
## Summary

`Button.svelte`'s tooltip migrated from `@melt-ui/svelte`'s `createTooltip` to `bits-ui`'s `Tooltip`, following the exact same `Root`/`Trigger` (via `child` snippet)/`Content`/`Arrow` composition already established in `UserAvatar.svelte` (#780).

The tooltip is now only wrapped around the button when a `tooltip` prop is actually passed — previously `createTooltip()` was instantiated unconditionally for every `Button`, even ones with no tooltip.

`@melt-ui/svelte` is still needed for Dialog, the three DropdownMenu components, and Toaster — tracked in #781–#784 and #787.

## Verification

- `pnpm check` / `pnpm lint` — clean
- Ran the Svelte MCP `svelte-autofixer` — no issues
- Manually verified in a running instance (logged in with test credentials): opened a note, exercised the Cancel/Manage sharing/Choose colour/Delete/Bold/Italic/Underline/Save buttons — all render and click correctly, no console errors. Also confirmed the migrated `Button` composes correctly as menu items inside `ColourPicker.svelte` (still on `@melt-ui/svelte`, separate migration in #782).
- Didn't have friend data available to visually trigger a hover tooltip in this pass, but the composition is identical to the pattern already verified working in #780
- Ran `/caveman-review` against the diff: no bugs or risks found

Fixes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button tooltip behavior and consistency.
  * Preserved loading indicators and button content across tooltip and non-tooltip buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->