### PR TITLE
fix: add missing Tooltip.Provider (production bug)

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import './app.css';
+	import { Tooltip } from 'bits-ui';
 	import Toaster from '$components/Toaster.svelte';
 	import { setBoardState } from '$lib/state/boardState.svelte';
 	import { setToastMessages } from '$lib/state/toastMessages.svelte';
@@ -12,5 +13,7 @@
 	setUserState();
 </script>
 
-<Toaster />
-{@render children()}
+<Tooltip.Provider>
+	<Toaster />
+	{@render children()}
+</Tooltip.Provider>


### PR DESCRIPTION
## Summary

**Production bug**, reported directly by the user via a browser console error: `Error: Context "Tooltip.Provider" not found`.

`bits-ui`'s `Tooltip.Root` requires an ancestor `Tooltip.Provider` in the component tree — confirmed in its source (`TooltipRootState`'s constructor calls `TooltipProviderContext.get()` unconditionally). It's not optional and nothing in the app was providing one. Every tooltip-enabled `UserAvatar` (#780) or `Button` (#790) has been throwing this error in production since those merged.

Fix: mount `Tooltip.Provider` once in the root layout (`src/routes/+layout.svelte`), wrapping everything — the standard place for it per `bits-ui`'s own docs, since one Provider covers every nested `Tooltip.Root` in the tree.

## Why this wasn't caught before merging #780/#790

Both PRs' manual verification only exercised code paths where `showTooltip={false}` or no `tooltip` prop was passed (the test account had no friends and no shared notes, which are the only places a real tooltip renders). Neither PR ever actually constructed a real `Tooltip.Root`, so the missing-Provider error never had a chance to surface. Noted for future migrations in this track (#781–#784, #787 remaining) — verification needs to specifically exercise a tooltip-bearing instance, not just the tooltip-less branches.

## Verification

- `pnpm check` / `pnpm lint` — clean
- Reproduced the actual bug locally first (rendered a `Tooltip.Root` via a real pending friend invite's "Cancel" button — confirmed the exact same "Context not found" error), then confirmed the fix resolves it: hovering the button now shows the tooltip correctly with no console error
- Ran `/caveman-review` against the diff: no bugs or risks found

## Follow-up

Noticed a separate, lower-severity `[svelte] derived_inert` dev-mode warning ("Reading a derived belonging to a now-destroyed effect may result in stale values") when a tooltip-wrapped button is removed from the DOM (e.g. cancelling the invite that had the tooltip). This is a dev-only diagnostic (stripped in production builds), not a crash — worth keeping an eye on as more `bits-ui` migrations land, but not blocking this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)