### PR TITLE
Migrate ColourPicker.svelte's dropdown menu to bits-ui

### DIFF
--- a/src/components/ColourPicker.svelte
+++ b/src/components/ColourPicker.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { slide } from 'svelte/transition';
-	import { createDropdownMenu, melt } from '@melt-ui/svelte';
+	import { DropdownMenu } from 'bits-ui';
 
 	import { colours, type Colour } from '$lib/colours';
 	import { Paintbrush, Minus } from '@lucide/svelte';
@@ -13,57 +13,54 @@
 
 	let { onselect }: Props = $props();
 
-	const {
-		elements: { trigger, menu, item },
-		states: { open }
-	} = createDropdownMenu({
-		forceVisible: true,
-		loop: true,
-		preventScroll: true,
-		closeOnOutsideClick: true,
-		positioning: { placement: 'bottom' },
-		onOutsideClick: () => {
-			$open = false;
-		}
-	});
-
 	function handleColourClick(colour: Colour | null) {
 		onselect(colour);
 	}
 </script>
 
-<div use:melt={$trigger}>
-	<Button variant="ghost" label="Choose colour">
-		<Paintbrush />
-	</Button>
-</div>
-{#if $open}
-	<!-- pointer-events-auto: when this opens from within Dialog.svelte (bits-ui), the dialog's
-		scroll lock sets pointer-events: none on <body>; this menu is portalled outside the
-		dialog's own DOM subtree, so it needs to opt back in explicitly to stay clickable. -->
-	<div
-		class="z-dropdown pointer-events-auto flex flex-col gap-1 bg-transparent"
-		in:slide={{ duration: 100 }}
-		use:melt={$menu}
-	>
-		<div class="block" use:melt={$item}>
-			<button
-				aria-label="No colour"
-				class="dark:bg-dark flex h-12 w-12 items-center justify-center rounded-full border-2 border-slate-400 bg-white text-gray-600 dark:border-slate-200"
-				onclick={() => handleColourClick(null)}
-			>
-				<Minus size={30} />
-			</button>
-		</div>
-		{#each colours as { cssClass, name }}
-			<div class="block" use:melt={$item}>
-				<button
-					aria-label={name}
-					title={name}
-					class="h-12 w-12 rounded-full border-2 border-slate-400 dark:border dark:border-slate-200 {cssClass}"
-					onclick={() => handleColourClick(name)}
-				></button>
+<DropdownMenu.Root>
+	<DropdownMenu.Trigger>
+		{#snippet child({ props })}
+			<div {...props}>
+				<Button variant="ghost" label="Choose colour">
+					<Paintbrush />
+				</Button>
 			</div>
-		{/each}
-	</div>
-{/if}
+		{/snippet}
+	</DropdownMenu.Trigger>
+	<DropdownMenu.Portal>
+		<DropdownMenu.Content forceMount loop side="bottom">
+			{#snippet child({ props, open, wrapperProps })}
+				{#if open}
+					<div {...wrapperProps}>
+						<div
+							{...props}
+							class="z-dropdown flex flex-col gap-1 bg-transparent"
+							in:slide={{ duration: 100 }}
+						>
+							<DropdownMenu.Item onSelect={() => handleColourClick(null)}>
+								<button
+									aria-label="No colour"
+									class="dark:bg-dark flex h-12 w-12 items-center justify-center rounded-full border-2 border-slate-400 bg-white text-gray-600 dark:border-slate-200"
+									tabindex={-1}
+								>
+									<Minus size={30} />
+								</button>
+							</DropdownMenu.Item>
+							{#each colours as { cssClass, name } (name)}
+								<DropdownMenu.Item onSelect={() => handleColourClick(name)}>
+									<button
+										aria-label={name}
+										title={name}
+										class="h-12 w-12 rounded-full border-2 border-slate-400 dark:border dark:border-slate-200 {cssClass}"
+										tabindex={-1}
+									></button>
+								</DropdownMenu.Item>
+							{/each}
+						</div>
+					</div>
+				{/if}
+			{/snippet}
+		</DropdownMenu.Content>
+	</DropdownMenu.Portal>
+</DropdownMenu.Root>


### PR DESCRIPTION
## Summary

`ColourPicker.svelte`'s `createDropdownMenu` (`@melt-ui/svelte`) migrated to `bits-ui`'s `DropdownMenu.Root`/`Trigger`/`Portal`/`Content`/`Item`, using the `forceMount` + `child` snippet pattern to keep the existing `transition:slide` directive.

Since this menu now opens from bits-ui talking to bits-ui (rather than `@melt-ui/svelte` portalled as a DOM sibling of the `bits-ui` `Dialog` it opens from — see #792), the `pointer-events-auto` workaround added in #792 is no longer needed and has been removed. Confirmed `bits-ui`'s own `Menu.Content` already sets `pointer-events: auto` on itself, same mechanism as `Dialog`/`Tooltip`.

## A real bug caught during manual testing

Initial version wired colour selection to the inner `<button>`'s `onclick` (mirroring the old melt-ui structure). That only fires for **mouse clicks** — keyboard selection (Enter/Space while an item is focused) goes through the `Item`'s own internal select handling, which silently did nothing without a callback wired up. Confirmed by testing: arrow-key navigating to a swatch and pressing Enter did **not** change the note's colour, while clicking the same swatch with a mouse did.

Fixed by moving the selection logic to each `Item`'s `onSelect` callback (fires uniformly for both mouse and keyboard), and setting `tabindex={-1}` on the inner buttons so they don't create a redundant second tab stop alongside the `Item`'s own roving-tabindex focus management.

Also added a missing key to the `colours` `{#each}` block (`(name)`, since names are unique) — the Svelte MCP `svelte-autofixer` flagged it while reviewing the new markup.

## Verification

- `pnpm check` / `pnpm lint` — clean
- Ran the Svelte MCP `svelte-autofixer` — caught the missing `{#each}` key
- Manually verified in a running instance (logged in with test credentials), opening a note and testing the colour picker while it's inside the `Dialog`:
  - Mouse click on a swatch: colour applies correctly, menu closes, no console errors
  - Keyboard: arrow-key navigation moves focus with visible focus ring; **Enter did nothing until the `onSelect` fix**, then correctly applied the colour
  - Outside click (clicking the note title while the menu is open): closes just the menu, `Dialog` stays open, no console errors
  - Confirmed via direct DOM inspection (`document.querySelector('.z-dialog').className`) that the note's background colour class actually changes on each interaction, not just that the menu visually closes

## Follow-up

Remaining on the `bits-ui` track: #783 (ProfileMenu), #784 (Share — same `pointer-events-auto` workaround can be removed there too once migrated), #787 (Toaster → svelte-sonner).

Fixes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the colour picker’s dropdown interaction and selection behavior.
  * Preserved the “No colour” option and available colour choices.
  * Added an animated transition when opening the colour menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->