### PR TITLE
Migrate Share.svelte's dropdown menu to bits-ui

### DIFF
--- a/src/components/Share.svelte
+++ b/src/components/Share.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { FriendSelection } from '$lib/types';
-	import { createDropdownMenu, melt } from '@melt-ui/svelte';
+	import { DropdownMenu } from 'bits-ui';
 	import { UserPlus, CirclePlus, Check, Minus } from '@lucide/svelte';
 
 	import Button from './Button.svelte';
@@ -19,56 +19,60 @@
 	};
 
 	let { friends, noteId, ontogglefriend }: Props = $props();
-
-	const {
-		elements: { trigger, menu, item },
-		states: { open }
-	} = createDropdownMenu({
-		closeOnItemClick: false,
-		forceVisible: true,
-		loop: true,
-		preventScroll: true,
-		positioning: { placement: 'bottom' },
-		onOutsideClick: () => {
-			$open = false;
-		}
-	});
 </script>
 
-<div use:melt={$trigger}>
-	<Button variant="ghost" label="Manage sharing">
-		<UserPlus />
-	</Button>
-</div>
-{#if $open}
-	<!-- pointer-events-auto: when this opens from within Dialog.svelte (bits-ui), the dialog's
-		scroll lock sets pointer-events: none on <body>; this menu is portalled outside the
-		dialog's own DOM subtree, so it needs to opt back in explicitly to stay clickable. -->
-	<div
-		use:melt={$menu}
-		in:slide={{ duration: 100 }}
-		class="z-dropdown dark:bg-dark pointer-events-auto flex w-96 flex-col gap-1 rounded-lg border bg-white p-2 shadow-lg"
-	>
-		<a
-			class="dark:bg-dark flex items-center rounded-lg bg-white p-2 hover:ring-2"
-			href={`/my/friends/add?noteId=${noteId}`}
-			use:melt={$item}
-		>
-			<CirclePlus size={30} /> &nbsp; Invite friend
-		</a>
-		{#each friends as { id, noteEditorId, name, selected }}
-			<button
-				class="dark:bg-dark flex items-center rounded-lg bg-white p-2 hover:ring-2"
-				aria-label={selected ? `${name}, selected` : `${name}, not selected`}
-				onclick={() => ontogglefriend({ id: noteEditorId, friendUserId: id, selected: !selected })}
-				use:melt={$item}
-			>
-				{#if selected}
-					<Check /> &nbsp;
-				{:else}
-					<Minus /> &nbsp;
+<DropdownMenu.Root>
+	<DropdownMenu.Trigger>
+		{#snippet child({ props })}
+			<div {...props}>
+				<Button variant="ghost" label="Manage sharing">
+					<UserPlus />
+				</Button>
+			</div>
+		{/snippet}
+	</DropdownMenu.Trigger>
+	<DropdownMenu.Portal>
+		<DropdownMenu.Content forceMount loop side="bottom">
+			{#snippet child({ props, open, wrapperProps })}
+				{#if open}
+					<div {...wrapperProps}>
+						<div
+							{...props}
+							in:slide={{ duration: 100 }}
+							class="z-dropdown dark:bg-dark flex w-96 flex-col gap-1 rounded-lg border bg-white p-2 shadow-lg"
+						>
+							<DropdownMenu.Item>
+								{#snippet child({ props: itemProps })}
+									<a
+										{...itemProps}
+										class="dark:bg-dark flex items-center rounded-lg bg-white p-2 hover:ring-2"
+										href={`/my/friends/add?noteId=${noteId}`}
+									>
+										<CirclePlus size={30} /> &nbsp; Invite friend
+									</a>
+								{/snippet}
+							</DropdownMenu.Item>
+							{#each friends as { id, noteEditorId, name, selected } (id)}
+								<DropdownMenu.CheckboxItem
+									checked={selected}
+									closeOnSelect={false}
+									onCheckedChange={() =>
+										ontogglefriend({ id: noteEditorId, friendUserId: id, selected: !selected })}
+									aria-label={selected ? `${name}, selected` : `${name}, not selected`}
+									class="dark:bg-dark flex items-center rounded-lg bg-white p-2 hover:ring-2"
+								>
+									{#if selected}
+										<Check /> &nbsp;
+									{:else}
+										<Minus /> &nbsp;
+									{/if}
+									{name}
+								</DropdownMenu.CheckboxItem>
+							{/each}
+						</div>
+					</div>
 				{/if}
-				{name}
-			</button>{/each}
-	</div>
-{/if}
+			{/snippet}
+		</DropdownMenu.Content>
+	</DropdownMenu.Portal>
+</DropdownMenu.Root>


### PR DESCRIPTION
## Summary

`Share.svelte`'s `createDropdownMenu` (`@melt-ui/svelte`) migrated to `bits-ui`'s `DropdownMenu.Root`/`Trigger`/`Portal`/`Content`/`Item`/`CheckboxItem`.

- The "Invite friend" link uses the `forceMount` + `child` snippet pattern to render a real `<a href>` (needs actual navigation, not a synthetic action).
- The toggleable friend list uses `CheckboxItem`'s own `checked`/`onCheckedChange`, with `closeOnSelect={false}` to preserve the original "menu stays open while toggling multiple friends" behavior (`closeOnItemClick: false` in the old melt-ui config).

Since this menu is now bits-ui talking to bits-ui rather than `@melt-ui/svelte` portalled as a DOM sibling of the `bits-ui` `Dialog` it opens from, the `pointer-events-auto` workaround added in #792 is no longer needed and has been removed — same cleanup as `ColourPicker` in #793.

## Applying the lesson from #793

`ColourPicker`'s migration initially wired selection to the inner `<button>`'s `onclick`, which only fires for mouse clicks — keyboard selection silently did nothing. For `Share`, I used `CheckboxItem`'s own `onCheckedChange` from the start, which is the single source of truth for both mouse and keyboard, and verified both explicitly rather than assuming it'd work.

Verifying this properly required an actual friend connection, which the test account didn't have. Seeded one directly via Prisma against the same DB (`User` + two `UserConnection` rows), tested against it, then deleted all of it afterward — confirmed clean via the friends page showing no friends again post-cleanup.

## Verification

- `pnpm check` / `pnpm lint` — clean
- Ran the Svelte MCP `svelte-autofixer` — no issues
- Manually verified in a running instance with a seeded test friend, opening a note and testing Share from inside the `Dialog`:
  - Mouse click on the friend checkbox item: toggles `checked` state, menu stays open, no console errors
  - Keyboard: focus + Enter toggles the same state correctly (unlike #793's initial ColourPicker attempt)
  - Confirmed the toggle persists server-side — closed and reopened the note (full page reload) and the shared state was still correct
  - "Invite friend" link navigates to `/my/friends/add?noteId=...` correctly
- Added a missing key to the `friends` `{#each}` block (`(id)`) while touching it
- Ran `/caveman-review` against the diff: no bugs or risks found

## Follow-up

Remaining on the `bits-ui` track: #783 (ProfileMenu — the last dropdown menu), #787 (Toaster → svelte-sonner, the last `@melt-ui/svelte` piece overall).

Fixes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)