### PR TITLE
Migrate ProfileMenu.svelte's dropdown menu to bits-ui

### DIFF
--- a/src/components/ProfileMenu.svelte
+++ b/src/components/ProfileMenu.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { fly } from 'svelte/transition';
-	import { createDropdownMenu, melt } from '@melt-ui/svelte';
+	import { DropdownMenu } from 'bits-ui';
 
 	import { Settings, LogOut, type LucideIcon } from '@lucide/svelte';
 	import UserAvatar from './UserAvatar.svelte';
@@ -13,31 +13,21 @@
 
 	let { userPicture, email, name }: Props = $props();
 
-	const {
-		elements: { trigger, menu, item },
-		states: { open }
-	} = createDropdownMenu({
-		forceVisible: true,
-		loop: true,
-		preventScroll: true,
-		closeOnOutsideClick: true,
-		positioning: { placement: 'bottom-end' }
-	});
-
 	type MenuLinkProps = {
 		href: string;
 		text: string;
 		borderTop?: boolean;
 		icon: LucideIcon;
+		itemProps: Record<string, unknown>;
 	};
 </script>
 
-{#snippet MenuLink({ borderTop = false, href, icon: Icon, text }: MenuLinkProps)}
+{#snippet MenuLink({ borderTop = false, href, icon: Icon, text, itemProps }: MenuLinkProps)}
 	{#if borderTop}
 		<div class="dark:border-dark-border mt-2 border-t border-gray-200"></div>
 	{/if}
 	<a
-		use:melt={$item}
+		{...itemProps}
 		class="hover:bg-slate hover:bg-background dark:hover:bg-dark-hover mt-2 flex w-full gap-2 rounded-lg p-2"
 		{href}
 	>
@@ -46,33 +36,52 @@
 	</a>
 {/snippet}
 
-<button type="button" use:melt={$trigger} aria-label="user menu">
-	<UserAvatar picture={userPicture} {name} size={8} showTooltip={false} />
-</button>
-
-{#if $open}
-	<div
-		class="menu z-dropdown dark:border-dark-border dark:bg-dark flex w-72 flex-col justify-between rounded-lg border bg-white p-6"
-		use:melt={$menu}
-		transition:fly={{ duration: 150, y: -10 }}
-	>
-		<div class="flex">
-			<UserAvatar picture={userPicture} {name} size={8} showTooltip={false} />
-			<div class="ml-4 flex flex-col truncate">
-				<span class="truncate font-bold">{name}</span>
-				<span class="truncate text-xs text-gray-500">{email}</span>
-			</div>
-		</div>
-		{@render MenuLink({
-			text: 'Account settings',
-			href: '/my/account',
-			icon: Settings
-		})}
-		{@render MenuLink({
-			text: 'Logout',
-			href: '/api/auth/logout',
-			icon: LogOut,
-			borderTop: true
-		})}
-	</div>
-{/if}
+<DropdownMenu.Root>
+	<DropdownMenu.Trigger aria-label="user menu">
+		<UserAvatar picture={userPicture} {name} size={8} showTooltip={false} />
+	</DropdownMenu.Trigger>
+	<DropdownMenu.Portal>
+		<DropdownMenu.Content forceMount loop side="bottom" align="end">
+			{#snippet child({ props, open, wrapperProps })}
+				{#if open}
+					<div {...wrapperProps}>
+						<div
+							{...props}
+							transition:fly={{ duration: 150, y: -10 }}
+							class="menu z-dropdown dark:border-dark-border dark:bg-dark flex w-72 flex-col justify-between rounded-lg border bg-white p-6"
+						>
+							<div class="flex">
+								<UserAvatar picture={userPicture} {name} size={8} showTooltip={false} />
+								<div class="ml-4 flex flex-col truncate">
+									<span class="truncate font-bold">{name}</span>
+									<span class="truncate text-xs text-gray-500">{email}</span>
+								</div>
+							</div>
+							<DropdownMenu.Item>
+								{#snippet child({ props: itemProps })}
+									{@render MenuLink({
+										text: 'Account settings',
+										href: '/my/account',
+										icon: Settings,
+										itemProps
+									})}
+								{/snippet}
+							</DropdownMenu.Item>
+							<DropdownMenu.Item>
+								{#snippet child({ props: itemProps })}
+									{@render MenuLink({
+										text: 'Logout',
+										href: '/api/auth/logout',
+										icon: LogOut,
+										borderTop: true,
+										itemProps
+									})}
+								{/snippet}
+							</DropdownMenu.Item>
+						</div>
+					</div>
+				{/if}
+			{/snippet}
+		</DropdownMenu.Content>
+	</DropdownMenu.Portal>
+</DropdownMenu.Root>


### PR DESCRIPTION
## Summary

`ProfileMenu.svelte`'s `createDropdownMenu` (`@melt-ui/svelte`) migrated to `bits-ui`'s `DropdownMenu.Root`/`Trigger`/`Portal`/`Content`/`Item`.

Simpler than `ColourPicker`/`Share` (#793/#794): the trigger is just `UserAvatar` placed as children of `Trigger`'s own default button rendering — no `child` snippet needed there, since `Trigger` already renders a `<button>` by default and there's no nested `Button` component to wrap this time. `side="bottom" align="end"` replicates the old `positioning: { placement: 'bottom-end' }`.

Last of the three dropdown-menu migrations. `@melt-ui/svelte` is now only used by `Toaster.svelte` (#787).

## A pre-existing bug found, not a regression

While testing Logout, found it throws a console 404 (`Error: Not found: /api/auth/logout`) — SvelteKit's client-side router intercepts the link to what's actually an API route. **Confirmed via `git stash` that this reproduces identically on the old `@melt-ui/svelte` code on `main`** — not something this migration introduced. Logout still functions correctly (the user does get logged out) despite the console error. Filed as #795 rather than fixed here, since it's unrelated to the dropdown-menu migration and deserves its own scoped PR.

## Verification

- `pnpm check` / `pnpm lint` — clean
- Ran the Svelte MCP `svelte-autofixer` — no issues
- Manually verified in a running instance (logged in with test credentials):
  - Mouse click on trigger opens the menu with avatar/name/email header rendering correctly
  - Keyboard: arrow-key navigation + Enter activates "Account settings" correctly
  - Mouse click on "Account settings" navigates correctly
  - Outside click closes the menu without navigating
  - Logout (mouse click) logs out correctly (aside from the pre-existing #795 console noise)
- Ran `/caveman-review` against the diff: no bugs or risks found

## Follow-up

Only #787 (Toaster → svelte-sonner) remains to fully remove `@melt-ui/svelte` from the app.

Fixes #783

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the profile menu’s dropdown implementation for improved consistency and interaction handling.
  * Preserved existing menu options, including Account settings and Logout, with their links and visual styling unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->