### PR TITLE
Replace Toaster.svelte's @melt-ui/svelte toaster with svelte-sonner

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
 		"@eslint/js": "10.0.1",
 		"@faker-js/faker": "10.5.0",
 		"@fontsource/fira-mono": "5.3.0",
-		"@melt-ui/pp": "0.3.2",
-		"@melt-ui/svelte": "0.86.6",
 		"@neoconfetti/svelte": "2.2.2",
 		"@playwright/test": "1.61.1",
 		"@sveltejs/adapter-auto": "7.0.1",
@@ -75,6 +73,7 @@
 		"nanoid": "6.0.0",
 		"neverthrow": "8.2.0",
 		"prisma-field-encryption": "1.6.0",
+		"svelte-sonner": "1.1.1",
 		"zod": "4.4.3"
 	},
 	"lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       prisma-field-encryption:
         specifier: 1.6.0
         version: 1.6.0(@prisma/client@6.19.3(prisma@6.19.3(typescript@6.0.3))(typescript@6.0.3))(supports-color@7.2.0)
+      svelte-sonner:
+        specifier: 1.1.1
+        version: 1.1.1(svelte@5.56.7(@typescript-eslint/types@8.65.0))
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -72,12 +75,6 @@ importers:
       '@fontsource/fira-mono':
         specifier: 5.3.0
         version: 5.3.0
-      '@melt-ui/pp':
-        specifier: 0.3.2
-        version: 0.3.2(@melt-ui/svelte@0.86.6(svelte@5.56.7(@typescript-eslint/types@8.65.0)))(svelte@5.56.7(@typescript-eslint/types@8.65.0))
-      '@melt-ui/svelte':
-        specifier: 0.86.6
-        version: 0.86.6(svelte@5.56.7(@typescript-eslint/types@8.65.0))
       '@neoconfetti/svelte':
         specifier: 2.2.2
         version: 2.2.2(svelte@5.56.7(@typescript-eslint/types@8.65.0))
@@ -549,17 +546,6 @@ packages:
     resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
     engines: {node: '>=18'}
     hasBin: true
-
-  '@melt-ui/pp@0.3.2':
-    resolution: {integrity: sha512-xKkPvaIAFinklLXcQOpwZ8YSpqAFxykjWf8Y/fSJQwsixV/0rcFs07hJ49hJjPy5vItvw5Qa0uOjzFUbXzBypQ==}
-    peerDependencies:
-      '@melt-ui/svelte': '>= 0.29.0'
-      svelte: ^3.55.0 || ^4.0.0 || ^5.0.0-next.1
-
-  '@melt-ui/svelte@0.86.6':
-    resolution: {integrity: sha512-Jer+M7DgIwT5IHfTayb4Iw/fkkxWNmC/mqn/nMh9JrbPbkxmyabfLQnhJ+JDn5HK77f84j34lubO3iqFtYAfMg==}
-    peerDependencies:
-      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0-next.118
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -1538,9 +1524,6 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  focus-trap@7.8.0:
-    resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
-
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1825,11 +1808,6 @@ packages:
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@5.1.16:
-    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
-    engines: {node: ^18 || >=20}
     hasBin: true
 
   nanoid@6.0.0:
@@ -2140,6 +2118,11 @@ packages:
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
+  runed@0.28.0:
+    resolution: {integrity: sha512-k2xx7RuO9hWcdd9f+8JoBeqWtYrm5CALfgpkg2YDB80ds/QE4w0qqu34A7fqiAwiBBSBQOid7TLxwxVC27ymWQ==}
+    peerDependencies:
+      svelte: ^5.7.0
+
   runed@0.35.1:
     resolution: {integrity: sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==}
     peerDependencies:
@@ -2220,6 +2203,11 @@ packages:
     peerDependenciesMeta:
       svelte:
         optional: true
+
+  svelte-sonner@1.1.1:
+    resolution: {integrity: sha512-5cd3p7wa4cq0NsqslMwdlPb7x1JglEZ/GKrLePWNr5bCxR1nagAVrY01FRFrXfUGs41miLt3C327+8XJo5BzZw==}
+    peerDependencies:
+      svelte: ^5.0.0
 
   svelte-toolbelt@0.10.6:
     resolution: {integrity: sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==}
@@ -2841,23 +2829,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  '@melt-ui/pp@0.3.2(@melt-ui/svelte@0.86.6(svelte@5.56.7(@typescript-eslint/types@8.65.0)))(svelte@5.56.7(@typescript-eslint/types@8.65.0))':
-    dependencies:
-      '@melt-ui/svelte': 0.86.6(svelte@5.56.7(@typescript-eslint/types@8.65.0))
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-      svelte: 5.56.7(@typescript-eslint/types@8.65.0)
-
-  '@melt-ui/svelte@0.86.6(svelte@5.56.7(@typescript-eslint/types@8.65.0))':
-    dependencies:
-      '@floating-ui/core': 1.7.5
-      '@floating-ui/dom': 1.7.6
-      '@internationalized/date': 3.12.2
-      dequal: 2.0.3
-      focus-trap: 7.8.0
-      nanoid: 5.1.16
-      svelte: 5.56.7(@typescript-eslint/types@8.65.0)
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -3850,10 +3821,6 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  focus-trap@7.8.0:
-    dependencies:
-      tabbable: 6.4.0
-
   fsevents@2.3.2:
     optional: true
 
@@ -4079,8 +4046,6 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.16: {}
-
-  nanoid@5.1.16: {}
 
   nanoid@6.0.0: {}
 
@@ -4360,6 +4325,11 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
+  runed@0.28.0(svelte@5.56.7(@typescript-eslint/types@8.65.0)):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.56.7(@typescript-eslint/types@8.65.0)
+
   runed@0.35.1(@sveltejs/kit@2.70.1(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.7(@typescript-eslint/types@8.65.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.7(@typescript-eslint/types@8.65.0))(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.7(@typescript-eslint/types@8.65.0)):
     dependencies:
       dequal: 2.0.3
@@ -4434,6 +4404,11 @@ snapshots:
       postcss-selector-parser: 7.1.4
       semver: 7.8.4
     optionalDependencies:
+      svelte: 5.56.7(@typescript-eslint/types@8.65.0)
+
+  svelte-sonner@1.1.1(svelte@5.56.7(@typescript-eslint/types@8.65.0)):
+    dependencies:
+      runed: 0.28.0(svelte@5.56.7(@typescript-eslint/types@8.65.0))
       svelte: 5.56.7(@typescript-eslint/types@8.65.0)
 
   svelte-toolbelt@0.10.6(@sveltejs/kit@2.70.1(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.7(@typescript-eslint/types@8.65.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.7(@typescript-eslint/types@8.65.0))(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.7(@typescript-eslint/types@8.65.0)):

--- a/src/components/Toaster.svelte
+++ b/src/components/Toaster.svelte
@@ -2,4 +2,4 @@
 	import { Toaster as SonnerToaster } from 'svelte-sonner';
 </script>
 
-<SonnerToaster position="top-center" richColors />
+<SonnerToaster position="bottom-center" richColors />

--- a/src/components/Toaster.svelte
+++ b/src/components/Toaster.svelte
@@ -1,47 +1,5 @@
 <script lang="ts">
-	import { slide } from 'svelte/transition';
-	import { createToaster, melt } from '@melt-ui/svelte';
-
-	import { getToastMessages } from '$lib/state/toastMessages.svelte';
-	import { X } from '@lucide/svelte';
-	import type { ToastMessage } from '$lib/types';
-
-	const toastMessages = getToastMessages();
-
-	const {
-		elements: { content, description, close },
-		helpers,
-		states: { toasts },
-		actions: { portal }
-	} = createToaster<ToastMessage>({});
-
-	$effect(() => {
-		toastMessages.messages
-			.filter((m) => m.isShown === false)
-			.forEach((message) => {
-				helpers.addToast({ type: 'background', data: message });
-				message.isShown = true;
-			});
-	});
+	import { Toaster as SonnerToaster } from 'svelte-sonner';
 </script>
 
-<div use:portal class="z-toaster fixed top-2 left-1/2 w-80 -translate-x-1/2 transform">
-	{#each $toasts as { id, data } (id)}
-		<div use:melt={$content(id)}>
-			<div
-				in:slide={{ duration: 200 }}
-				out:slide={{ duration: 200 }}
-				class="mb-2 flex items-center justify-between rounded-lg p-4 text-sm shadow-lg dark:text-gray-900"
-				class:bg-red-300={data.type === 'error'}
-				class:bg-green-300={data.type === 'success'}
-			>
-				<div use:melt={$description(id)}>
-					{data.message}
-				</div>
-				<button use:melt={$close(id)} aria-label="close notification">
-					<X />
-				</button>
-			</div>
-		</div>
-	{/each}
-</div>
+<SonnerToaster position="top-center" richColors />

--- a/src/lib/state/toastMessages.svelte.ts
+++ b/src/lib/state/toastMessages.svelte.ts
@@ -1,23 +1,11 @@
 import { getContext, setContext } from 'svelte';
-import { nanoid } from 'nanoid';
+import { toast } from 'svelte-sonner';
 
 import { type ToastMessage } from '$lib/types';
 
-type ToastMessageWithId = ToastMessage & { id: string; isShown: boolean };
-
 export class ToastMessages {
-	messages: ToastMessageWithId[] = $state([]);
-
-	constructor() {}
-
 	addMessage(message: ToastMessage) {
-		const id = nanoid();
-
-		this.messages.push({
-			...message,
-			id,
-			isShown: false
-		});
+		toast[message.type](message.message);
 	}
 }
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,11 +1,10 @@
-import { preprocessMeltUI, sequence } from '@melt-ui/pp';
 import adapter from '@sveltejs/adapter-vercel';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 /** @type {import('@sveltejs/kit').Config}*/
 const config = {
 	// Consult https://kit.svelte.dev/docs/integrations#preprocessors
 	// for more information about preprocessors
-	preprocess: sequence([vitePreprocess(), preprocessMeltUI()]),
+	preprocess: vitePreprocess(),
 	kit: {
 		adapter: adapter({
 			runtime: 'nodejs22.x'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
 	ssr: {
-		noExternal: ['bits-ui']
+		noExternal: ['bits-ui', 'svelte-sonner']
 	},
 	server: {
 		port: 3377


### PR DESCRIPTION
## Summary

`Toaster.svelte`'s `createToaster` (`@melt-ui/svelte`) replaced with `svelte-sonner`'s own `<Toaster>` component.

`ToastMessages` simplifies from a stateful array + `$effect` bridge into a thin wrapper that calls `toast.success()`/`toast.error()` directly — **no call sites change** across the app (`toastMessages.addMessage(...)` still works exactly the same everywhere), since `svelte-sonner` owns its own toast queue/state internally rather than needing our own array + bridging effect.

**This was the last `@melt-ui/svelte` consumer in the app.** Removed the `@melt-ui/svelte` and `@melt-ui/pp` dependencies entirely, along with the `preprocessMeltUI` preprocessor in `svelte.config.js`. This closes out the migration started in #772.

Also added `svelte-sonner` to `vite.config.ts`'s `ssr.noExternal` — same reasoning as `bits-ui` (#780): it ships raw `.svelte` source (including a ~770-line global `<style>` block) rather than pre-compiled JS, so Vite needs to transform it during SSR.

## A verification detour worth mentioning

Testing this took much longer than expected because my checks kept landing after the toast's default 4-second auto-dismiss window — each `agent-browser` CLI round-trip has real overhead, and stacking several sequential checks after a click reliably blew past 4 seconds. I chased this as a suspected duplicate-module-instance bug for a while (added temporary debug logging, checked `toast.getActiveToasts()`, inspected computed styles) before proving conclusively — via a temporary `duration: Infinity` override — that the toast renders perfectly (icon, rich colour, text) and there was never a real bug. All debug code was removed before committing; the final diff is the clean implementation.

## Verification

- `pnpm check` / `pnpm lint` — clean
- `pnpm build` (full production build) — succeeds, confirming the `svelte.config.js` preprocessor removal doesn't break the build
- Ran the Svelte MCP `svelte-autofixer` — no issues
- Manually verified in a running instance:
  - Success path: submitted the account settings form, confirmed via DOM inspection and a visual screenshot that the toast renders correctly (green background, checkmark icon, "Account updated" text), positioned top-center as configured
  - Error path: intercepted the note-update API call to force a failure — confirmed the optimistic UI update was correctly reverted (same code path that also fires the error toast), and confirmed via source inspection that `toast.error()` is mechanically identical to `toast.success()` (same `create()` call, just a different `type` string)

Fixes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined toast notification experience with rich colors.
  * Notifications now appear immediately at the bottom center of the screen.
* **Bug Fixes**
  * Improved toast handling to provide more consistent and reliable feedback.
* **Refactor**
  * Simplified notification rendering and removed legacy toast-processing behavior.
  * Updated application configuration to support the new notification experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->