### PR TITLE
Replace onMount/onDestroy + bind:this with {@attach} in HtmlEditor

### DIFF
--- a/src/components/HtmlEditor.svelte
+++ b/src/components/HtmlEditor.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import { onMount, onDestroy } from 'svelte';
 	import { Editor, Extension } from '@tiptap/core';
 	import StarterKit from '@tiptap/starter-kit';
 	import HardBreak from '@tiptap/extension-hard-break';
 	import Placeholder from '@tiptap/extension-placeholder';
 	import Underline from '@tiptap/extension-underline';
+	import type { Attachment } from 'svelte/attachments';
 
 	type Props = {
 		id: string;
@@ -14,8 +14,6 @@
 	};
 
 	let { initialContent, id, onupdate, oneditorcreate }: Props = $props();
-	let element: HTMLDivElement;
-	let editor: Editor;
 
 	// Custom extension to make Shift+Enter create a new paragraph
 	const ShiftEnterParagraph = Extension.create({
@@ -29,10 +27,10 @@
 		}
 	});
 
-	onMount(() => {
+	const initEditor: Attachment<HTMLDivElement> = (element) => {
 		const viewportWidth = window.innerWidth;
 
-		editor = new Editor({
+		const editor = new Editor({
 			// Only focus on largrer screens
 			autofocus: viewportWidth < 1024 ? false : 'end',
 			editable: true,
@@ -42,7 +40,7 @@
 				}
 			},
 			injectCSS: true,
-			element: element,
+			element,
 			extensions: [
 				StarterKit.configure({
 					hardBreak: false // Disable default hard break to use custom one
@@ -69,13 +67,11 @@
 		});
 
 		oneditorcreate?.(editor);
-	});
 
-	onDestroy(() => {
-		if (editor) {
+		return () => {
 			editor.destroy();
-		}
-	});
+		};
+	};
 </script>
 
-<div class="h-full" {id} bind:this={element}></div>
+<div class="h-full" {id} {@attach initEditor}></div>

--- a/src/components/HtmlEditor.svelte
+++ b/src/components/HtmlEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { Editor, Extension } from '@tiptap/core';
 	import StarterKit from '@tiptap/starter-kit';
 	import HardBreak from '@tiptap/extension-hard-break';
@@ -27,51 +28,52 @@
 		}
 	});
 
-	const initEditor: Attachment<HTMLDivElement> = (element) => {
-		const viewportWidth = window.innerWidth;
+	const initEditor: Attachment<HTMLDivElement> = (element) =>
+		untrack(() => {
+			const viewportWidth = window.innerWidth;
 
-		const editor = new Editor({
-			// Only focus on largrer screens
-			autofocus: viewportWidth < 1024 ? false : 'end',
-			editable: true,
-			editorProps: {
-				attributes: {
-					class: 'prose h-full p-4 focus:outline-hidden dark:prose-invert'
-				}
-			},
-			injectCSS: true,
-			element,
-			extensions: [
-				StarterKit.configure({
-					hardBreak: false // Disable default hard break to use custom one
-				}),
-				// Custom HardBreak that triggers on Enter instead of Shift+Enter
-				HardBreak.extend({
-					addKeyboardShortcuts() {
-						return {
-							Enter: () => this.editor.commands.setHardBreak()
-						};
+			const editor = new Editor({
+				// Only focus on largrer screens
+				autofocus: viewportWidth < 1024 ? false : 'end',
+				editable: true,
+				editorProps: {
+					attributes: {
+						class: 'prose h-full p-4 focus:outline-hidden dark:prose-invert'
 					}
-				}),
-				ShiftEnterParagraph,
-				Placeholder.configure({
-					placeholder: 'Write a note ...'
-				}),
-				Underline
-			],
-			content: initialContent,
+				},
+				injectCSS: true,
+				element,
+				extensions: [
+					StarterKit.configure({
+						hardBreak: false // Disable default hard break to use custom one
+					}),
+					// Custom HardBreak that triggers on Enter instead of Shift+Enter
+					HardBreak.extend({
+						addKeyboardShortcuts() {
+							return {
+								Enter: () => this.editor.commands.setHardBreak()
+							};
+						}
+					}),
+					ShiftEnterParagraph,
+					Placeholder.configure({
+						placeholder: 'Write a note ...'
+					}),
+					Underline
+				],
+				content: initialContent,
 
-			onUpdate: ({ editor }) => {
-				onupdate(editor.getHTML(), editor.getText());
-			}
+				onUpdate: ({ editor }) => {
+					onupdate(editor.getHTML(), editor.getText());
+				}
+			});
+
+			oneditorcreate?.(editor);
+
+			return () => {
+				editor.destroy();
+			};
 		});
-
-		oneditorcreate?.(editor);
-
-		return () => {
-			editor.destroy();
-		};
-	};
 </script>
 
 <div class="h-full" {id} {@attach initEditor}></div>


### PR DESCRIPTION
## Summary

`HtmlEditor.svelte` ties the TipTap editor's creation/teardown directly to the `<div>`'s mount/unmount lifecycle via a single `{@attach}` attachment function, replacing the previous `bind:this={element}` + separate `onMount`/`onDestroy` hooks pair.

## A real bug CI caught, and the actual fix

The first version of this PR looked fine in my manual testing but broke `tests/home.test.ts` in CI: typing into a note only ever produced a single stray character instead of the full typed text.

Root cause: unlike `onMount` (which only ever runs once), `{@attach}` functions re-run whenever a reactive value read in their body changes. My attachment read `initialContent`/`onupdate`/`oneditorcreate` — all props. Since `onupdate` fires on every keystroke and updates the parent's `noteText` state (which is passed back in as `initialContent`), the attachment was destroying and recreating the **entire TipTap editor on every single character typed**, losing focus and content each time.

Confirmed this precisely rather than guessing: checked out the pre-`{@attach}` version and confirmed the Playwright suite passed there, reproduced the failure on the `{@attach}` version, then added temporary logging that showed the editor-creation code re-running after typing just one character.

Fix: wrap the attachment body in `untrack()`, which restores the original `onMount` semantics — the body runs once when the element mounts and no longer reacts to prop changes afterwards.

## Verification

- `pnpm check` / `pnpm lint` — clean
- Ran the Svelte MCP `svelte-autofixer` — no issues
- **Both Playwright suites pass**: `tests/home.test.ts` (the one that caught this) and `tests/noteManagement.test.ts`
- Manually re-verified via `agent-browser` against the fixed version:
  - Typed a full sentence into an existing note — landed correctly in full (previously only a stray character got through)
  - Typed into a brand-new note (the exact scenario the failing CI test exercises) — same correct result
  - Desktop autofocus, mobile no-autofocus, `oneditorcreate` → Toolbar wiring, and clean destroy/recreate across notes — all still verified working from the original pass

Fixes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)