### PR TITLE
Replace $effect + dummy counter in Toolbar with createSubscriber

### DIFF
--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { createSubscriber } from 'svelte/reactivity';
 	import type { Editor } from '@tiptap/core';
 	import { Bold, Italic, Underline } from '@lucide/svelte';
 
@@ -35,28 +36,27 @@
 		}
 	];
 
-	let transactionCount = $state(0);
+	// Re-renders activeMarks whenever the editor fires a transaction (e.g. the
+	// selection or formatting changes) - TipTap's own events aren't Svelte-reactive.
+	class EditorActiveMarks {
+		#editor: Editor;
+		#subscribe: () => void;
 
-	$effect(() => {
-		if (!editor) return;
+		constructor(editor: Editor) {
+			this.#editor = editor;
+			this.#subscribe = createSubscriber((update) => {
+				this.#editor.on('transaction', update);
+				return () => this.#editor.off('transaction', update);
+			});
+		}
 
-		const handleTransaction = () => {
-			transactionCount += 1;
-		};
+		isActive(mark: MarkName) {
+			this.#subscribe();
+			return this.#editor.isActive(mark);
+		}
+	}
 
-		editor.on('transaction', handleTransaction);
-		return () => editor.off('transaction', handleTransaction);
-	});
-
-	let activeMarks = $derived.by(() => {
-		// Reads transactionCount to register it as a dependency, forcing recompute on every TipTap transaction
-		const isTransactionTracked = transactionCount >= 0;
-		return {
-			bold: isTransactionTracked && (editor?.isActive('bold') ?? false),
-			italic: isTransactionTracked && (editor?.isActive('italic') ?? false),
-			underline: isTransactionTracked && (editor?.isActive('underline') ?? false)
-		};
-	});
+	let activeMarks = $derived(editor ? new EditorActiveMarks(editor) : null);
 </script>
 
 {#if editor}
@@ -70,7 +70,7 @@
 				variant="ghost"
 				size="sm"
 				{label}
-				active={activeMarks[mark]}
+				active={activeMarks?.isActive(mark) ?? false}
 				onclick={() => toggle(editor)}
 			>
 				<Icon size={iconSize} />


### PR DESCRIPTION
## Summary

`transactionCount` was a `$state` counter that existed purely to give `activeMarks` a reactive dependency, forcing recomputation whenever TipTap fired a `transaction` event — the exact scenario `createSubscriber` (`svelte/reactivity`) exists to handle without a fake counter or `$effect`.

`EditorActiveMarks` wraps one editor instance (guaranteed non-null by the time it's constructed, since the toolbar only renders inside `{#if editor}`) and exposes `isActive(mark)`, which subscribes lazily and re-triggers whenever the editor's own `transaction` event fires.

## Verification

Learned from #798's regression: verifying "it renders" isn't enough for reactivity changes — verified the actual reactive behavior itself, not just that it doesn't crash.

- `pnpm check` / `pnpm lint` — clean
- Ran the Svelte MCP `svelte-autofixer` — no new issues (flagged a pre-existing unkeyed `{#each}` in this file, unrelated to this change and already tracked separately)
- Both Playwright suites pass (`tests/home.test.ts`, `tests/noteManagement.test.ts`)
- Manually verified in a running instance (logged in with test credentials), via real DOM selection changes rather than just clicks:
  - Selecting text and clicking Bold toggles the active state correctly
  - Moving the cursor to unformatted text correctly clears the active state
  - Re-selecting the bold text correctly shows it active again — confirms the subscription reacts to selection/transaction changes, not just clicks
  - Switching between three different notes in a row works cleanly with no console errors, confirming the subscriber's cleanup correctly tears down each editor's `transaction` listener before the next one attaches

Fixes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved toolbar formatting-state updates so Bold, Italic, and Underline buttons more reliably reflect the editor’s current selection.
  * Ensured formatting indicators stay synchronized after editor changes and transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->