### PR TITLE
Add missing keys to {#each} blocks over mutable arrays

### DIFF
--- a/src/components/NoteEditor.svelte
+++ b/src/components/NoteEditor.svelte
@@ -163,7 +163,7 @@
 						tooltip="{note.owner.name} (owner)"
 					/>
 				{/if}
-				{#each editors as editor}
+				{#each editors as editor (editor.id)}
 					<UserAvatar picture={editor.picture || ''} name={editor.name || ''} size={7} />
 				{/each}
 			</div>

--- a/src/routes/my/friends/+page.svelte
+++ b/src/routes/my/friends/+page.svelte
@@ -228,7 +228,7 @@
 						})}
 					{/each}
 
-					{#each friendsState.friends as friend}
+					{#each friendsState.friends as friend (friend.id)}
 						{@render Friend({
 							name: friend.name!,
 							showPending: false,
@@ -251,7 +251,7 @@
 					{#if friendsState.pendingReceivedInvites.length === 0}
 						<p class="p-4">No incoming invites</p>
 					{:else}
-						{#each friendsState.pendingReceivedInvites as invite}
+						{#each friendsState.pendingReceivedInvites as invite (invite.id)}
 							{@render Friend({
 								name: invite.user.name!,
 								picture: invite.user.picture,


### PR DESCRIPTION
## Summary

`friendsState.friends`, `friendsState.pendingReceivedInvites`, and `NoteEditor`'s `editors` are all arrays whose items get removed/replaced at runtime (friend removal, invite accept/reject/cancel) and/or render with enter/exit transitions. Without a key, Svelte can't reliably track which DOM node maps to which item across an update.

## Verification

Verified against seeded test data (two friends, one sent invite, two received invites) rather than just static rendering — this specifically exercises the failure mode keys protect against (removing/replacing an item from the middle of the array, not just the last one):

- `pnpm check` / `pnpm lint` — clean
- Removing the first of two friends correctly kept the second, both immediately and after a full page reload
- Accepting the first of two received invites correctly kept the second as still pending, and the accepted one correctly became a friend after reload
- Cancelling a sent invite worked correctly
- `NoteEditor`'s shared-editors avatar row correctly renders both editors when a note is shared with two people

## Two unrelated pre-existing bugs found (not fixed here)

While testing, found:
1. Rejecting an invite POSTs to `/api/friends/accept/{id}` instead of a reject-specific endpoint, so it always 404s and the optimistic UI update reverts
2. `UserAvatar` has no fallback for a failed image load — an editor with no profile picture renders as a fully invisible avatar rather than a placeholder

Filing both as separate issues rather than expanding this PR's scope.

Fixes #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list rendering stability for note editors, friends, and pending invites.
  * Reduced potential display inconsistencies when these lists are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->