### PR TITLE
refactor: split my/+layout.svelte and my/friends/+page.svelte under 200 lines

### DIFF
--- a/src/components/FriendListItem.svelte
+++ b/src/components/FriendListItem.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { fade, slide } from 'svelte/transition';
+	import type { LucideIcon } from '@lucide/svelte';
+
+	import Button from './Button.svelte';
+	import UserAvatar from './UserAvatar.svelte';
+
+	type Action = {
+		id: string;
+		label: string;
+		icon: LucideIcon;
+		onclick: (id: string) => void;
+	};
+
+	type Props = {
+		name: string;
+		picture?: string | null;
+		showPending: boolean;
+		actions?: Action[];
+	};
+
+	let { name, picture, showPending, actions }: Props = $props();
+</script>
+
+<div
+	class="h-friend dark:bg-dark flex w-full items-center justify-between gap-2 p-4"
+	role="listitem"
+	in:fade
+	out:slide={{ duration: 250 }}
+>
+	<div class="flex items-center gap-2">
+		{#if picture}
+			<UserAvatar {picture} {name} size={8} showTooltip={false} />
+		{/if}
+
+		<div class:italic={showPending} class:text-gray-400={showPending}>
+			{name}
+			{#if showPending}
+				<span class="text-xs text-gray-400 italic">(pending)</span>
+			{/if}
+		</div>
+	</div>
+
+	<div class="flex gap-1">
+		{#if actions}
+			{#each actions as action}
+				{@const ActionIcon = action.icon}
+				<Button
+					variant="ghost"
+					label={action.label}
+					onclick={() => action.onclick(action.id)}
+					tooltip={action.label}
+				>
+					<ActionIcon />
+				</Button>
+			{/each}
+		{/if}
+	</div>
+</div>

--- a/src/lib/state/boardSync.svelte.ts
+++ b/src/lib/state/boardSync.svelte.ts
@@ -1,0 +1,109 @@
+import { isWriteQueueIdle, whenWriteQueueIdle } from '$lib/browserFetch';
+import {
+	getBoardSnapshot,
+	setBoardSnapshot,
+	getFriendsSnapshot,
+	setFriendsSnapshot
+} from './localCache';
+import type { BoardState } from './boardState.svelte';
+import type { FriendsState } from './friendsState.svelte';
+
+const maxReconcileAttempts = 3;
+const persistDebounceMs = 400;
+
+// Server is the source of truth, but only apply it when the optimistic
+// write queue is idle so in-flight local changes are not clobbered. If a
+// write races the fetch, retry so the re-fetch reflects the synced change.
+export async function refreshFromServer(boardState: BoardState, friendsState: FriendsState) {
+	for (let attempt = 0; attempt < maxReconcileAttempts; attempt++) {
+		await whenWriteQueueIdle();
+
+		const [boardResp, friendsResp] = await Promise.all([
+			fetch('/api/user/board'),
+			fetch('/api/friends')
+		]);
+		if (!boardResp.ok || !friendsResp.ok) {
+			throw new Error(
+				`Failed to load data: board ${boardResp.status}, friends ${friendsResp.status}`
+			);
+		}
+		const { board, sharedNotes, sharedNoteOwners } = await boardResp.json();
+		const { friends, pendingSentInvites, pendingReceivedInvites } = await friendsResp.json();
+
+		if (!isWriteQueueIdle()) {
+			continue;
+		}
+
+		boardState.setBoard(board, friends, sharedNotes, sharedNoteOwners);
+		friendsState.setState(friends, pendingSentInvites, pendingReceivedInvites);
+		return;
+	}
+	throw new Error('Could not reconcile with server: write queue never became idle');
+}
+
+export async function hydrateFromCache(
+	userId: string,
+	boardState: BoardState,
+	friendsState: FriendsState
+): Promise<{ boardHydrated: boolean; friendsHydrated: boolean }> {
+	if (!userId) {
+		return { boardHydrated: false, friendsHydrated: false };
+	}
+
+	const [boardSnapshot, friendsSnapshot] = await Promise.all([
+		getBoardSnapshot(userId),
+		getFriendsSnapshot(userId)
+	]);
+
+	const boardHydrated = !!boardSnapshot;
+	const friendsHydrated = !!friendsSnapshot;
+
+	if (boardSnapshot) {
+		boardState.hydrate(boardSnapshot);
+	}
+	if (friendsSnapshot) {
+		friendsState.hydrateState(friendsSnapshot);
+	}
+
+	return { boardHydrated, friendsHydrated };
+}
+
+// Persists state to the local cache (debounced) so the next load paints instantly.
+// Must be called synchronously during component initialization, since $effect
+// registers against the currently-active effect scope.
+export function setupLocalCachePersistence(
+	userId: string,
+	boardState: BoardState,
+	friendsState: FriendsState
+) {
+	$effect(() => {
+		const snapshot = $state.snapshot({
+			boardId: boardState.boardId,
+			noteOrder: boardState.noteOrder,
+			notes: boardState.notes,
+			friends: boardState.friends
+		});
+
+		if (!userId || boardState.loading) {
+			return;
+		}
+
+		const timer = setTimeout(() => setBoardSnapshot(userId, snapshot), persistDebounceMs);
+		return () => clearTimeout(timer);
+	});
+
+	$effect(() => {
+		const snapshot = $state.snapshot({
+			friends: friendsState.friends,
+			pendingSentInvites: friendsState.pendingSentInvites,
+			pendingReceivedInvites: friendsState.pendingReceivedInvites
+		});
+
+		if (!userId || friendsState.loading) {
+			return;
+		}
+
+		const timer = setTimeout(() => setFriendsSnapshot(userId, snapshot), persistDebounceMs);
+		return () => clearTimeout(timer);
+	});
+}

--- a/src/lib/state/friendsActions.ts
+++ b/src/lib/state/friendsActions.ts
@@ -1,0 +1,58 @@
+import { runOptimisticUpdate, tryFetch } from '$lib/browserFetch';
+import type { FriendsState } from './friendsState.svelte';
+import type { ToastMessages } from './toastMessages.svelte';
+
+export function createFriendsActions(friendsState: FriendsState, toastMessages: ToastMessages) {
+	async function cancelInvite(id: string) {
+		await runOptimisticUpdate({
+			apply: () => friendsState.cancelInvite(id),
+			request: () => tryFetch(`/api/invites/${id}`, { method: 'DELETE' }, { shouldParse: false }),
+			revert: ([index, invite]) => friendsState.addInviteAtIndex(index, invite),
+			errorMessage: 'There was a problem canceling the invite. Try again.',
+			toastMessages
+		});
+	}
+
+	async function removeFriend(id: string) {
+		await runOptimisticUpdate({
+			apply: () => friendsState.removeFriend(id),
+			request: () => tryFetch(`/api/friends/${id}`, { method: 'DELETE' }, { shouldParse: false }),
+			revert: ([index, friend]) => friendsState.addFriendAtIndex(index, friend),
+			errorMessage: 'There was a problem removing the friend. Try again.',
+			toastMessages
+		});
+	}
+
+	async function acceptInvite(id: string) {
+		const result = await runOptimisticUpdate({
+			apply: () => friendsState.acceptInvite(id),
+			request: () =>
+				tryFetch(
+					`/api/connections`,
+					{ method: 'POST', body: JSON.stringify({ inviteId: id }) },
+					{ clearQueueOnError: true }
+				),
+			revert: ([index, invite]) => {
+				friendsState.addReceivedInviteAtIndex(index, invite);
+				friendsState.removeFriend(invite.userId);
+			},
+			errorMessage: 'There was a problem removing the friend. Try again.',
+			toastMessages
+		});
+		if (result.type !== 'error') {
+			console.log('accepted invite', result.value);
+		}
+	}
+
+	async function rejectInvite(id: string) {
+		await runOptimisticUpdate({
+			apply: () => friendsState.rejectInvite(id),
+			request: () => tryFetch(`/api/friends/accept/${id}`, { method: 'POST' }),
+			revert: ([index, invite]) => friendsState.addReceivedInviteAtIndex(index, invite),
+			errorMessage: 'There was a problem removing the friend. Try again.',
+			toastMessages
+		});
+	}
+
+	return { cancelInvite, removeFriend, acceptInvite, rejectInvite };
+}

--- a/src/routes/my/+layout.svelte
+++ b/src/routes/my/+layout.svelte
@@ -6,20 +6,16 @@
 	import Note from '$components/Note.svelte';
 	import Search from '$components/Search.svelte';
 	import logo from '$lib/images/notes-main.png';
-	import { tryFetch, isWriteQueueIdle, whenWriteQueueIdle } from '$lib/browserFetch';
+	import { tryFetch } from '$lib/browserFetch';
 	import { getBoardState } from '$lib/state/boardState.svelte';
 	import { getToastMessages } from '$lib/state/toastMessages.svelte';
 	import { setFriendsState, getFriendsState } from '$lib/state/friendsState.svelte';
 	import { getUserState } from '$lib/state/userState.svelte';
 	import {
-		getBoardSnapshot,
-		setBoardSnapshot,
-		getFriendsSnapshot,
-		setFriendsSnapshot
-	} from '$lib/state/localCache';
-
-	const persistDebounceMs = 400;
-	const maxReconcileAttempts = 3;
+		refreshFromServer,
+		hydrateFromCache,
+		setupLocalCachePersistence
+	} from '$lib/state/boardSync.svelte';
 
 	let { children, data } = $props();
 
@@ -35,55 +31,12 @@
 
 	userState.setName(data.userData?.name ?? '');
 
-	async function refreshFromServer() {
-		// Server is the source of truth, but only apply it when the optimistic
-		// write queue is idle so in-flight local changes are not clobbered. If a
-		// write races the fetch, retry so the re-fetch reflects the synced change.
-		for (let attempt = 0; attempt < maxReconcileAttempts; attempt++) {
-			await whenWriteQueueIdle();
-
-			const [boardResp, friendsResp] = await Promise.all([
-				fetch('/api/user/board'),
-				fetch('/api/friends')
-			]);
-			if (!boardResp.ok || !friendsResp.ok) {
-				throw new Error(
-					`Failed to load data: board ${boardResp.status}, friends ${friendsResp.status}`
-				);
-			}
-			const { board, sharedNotes, sharedNoteOwners } = await boardResp.json();
-			const { friends, pendingSentInvites, pendingReceivedInvites } = await friendsResp.json();
-
-			if (!isWriteQueueIdle()) {
-				continue;
-			}
-
-			boardState.setBoard(board, friends, sharedNotes, sharedNoteOwners);
-			friendsState.setState(friends, pendingSentInvites, pendingReceivedInvites);
-			return;
-		}
-		throw new Error('Could not reconcile with server: write queue never became idle');
-	}
-
 	onMount(async () => {
-		let boardHydrated = false;
-		let friendsHydrated = false;
-
-		if (userId) {
-			const [boardSnapshot, friendsSnapshot] = await Promise.all([
-				getBoardSnapshot(userId),
-				getFriendsSnapshot(userId)
-			]);
-
-			if (boardSnapshot) {
-				boardState.hydrate(boardSnapshot);
-				boardHydrated = true;
-			}
-			if (friendsSnapshot) {
-				friendsState.hydrateState(friendsSnapshot);
-				friendsHydrated = true;
-			}
-		}
+		const { boardHydrated, friendsHydrated } = await hydrateFromCache(
+			userId,
+			boardState,
+			friendsState
+		);
 
 		// With a cached snapshot we can paint immediately and refresh silently;
 		// otherwise keep the skeleton until the first server response arrives.
@@ -91,7 +44,7 @@
 		friendsState.setLoading(!friendsHydrated);
 
 		try {
-			await refreshFromServer();
+			await refreshFromServer(boardState, friendsState);
 		} catch (err) {
 			console.error('Error loading data:', err);
 			if (!boardHydrated && !friendsHydrated) {
@@ -106,37 +59,7 @@
 		}
 	});
 
-	// Persist state to the local cache (debounced) so the next load paints instantly.
-	$effect(() => {
-		const snapshot = $state.snapshot({
-			boardId: boardState.boardId,
-			noteOrder: boardState.noteOrder,
-			notes: boardState.notes,
-			friends: boardState.friends
-		});
-
-		if (!userId || boardState.loading) {
-			return;
-		}
-
-		const timer = setTimeout(() => setBoardSnapshot(userId, snapshot), persistDebounceMs);
-		return () => clearTimeout(timer);
-	});
-
-	$effect(() => {
-		const snapshot = $state.snapshot({
-			friends: friendsState.friends,
-			pendingSentInvites: friendsState.pendingSentInvites,
-			pendingReceivedInvites: friendsState.pendingReceivedInvites
-		});
-
-		if (!userId || friendsState.loading) {
-			return;
-		}
-
-		const timer = setTimeout(() => setFriendsSnapshot(userId, snapshot), persistDebounceMs);
-		return () => clearTimeout(timer);
-	});
+	setupLocalCachePersistence(userId, boardState, friendsState);
 
 	async function handleCreateNote() {
 		const newNote = boardState.createNewNote();

--- a/src/routes/my/friends/+page.svelte
+++ b/src/routes/my/friends/+page.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
-	import { crossfade, slide, fade } from 'svelte/transition';
+	import { crossfade } from 'svelte/transition';
 	import { cubicInOut } from 'svelte/easing';
 	import { Tabs } from 'bits-ui';
 
-	import { Check, X, type LucideIcon } from '@lucide/svelte';
+	import { Check, X } from '@lucide/svelte';
 
 	import Skeleton from '$components/Skeleton.svelte';
-	import Button from '$components/Button.svelte';
 	import LinkButton from '$components/LinkButton.svelte';
-	import UserAvatar from '$components/UserAvatar.svelte';
+	import FriendListItem from '$components/FriendListItem.svelte';
 	import { getFriendsState } from '$lib/state/friendsState.svelte';
 	import { getToastMessages } from '$lib/state/toastMessages.svelte';
-	import { runOptimisticUpdate, tryFetch } from '$lib/browserFetch';
+	import { createFriendsActions } from '$lib/state/friendsActions';
 
 	const tabs = {
 		friends: 'Friends',
@@ -33,110 +32,20 @@
 
 	let loading = $derived(friendsState.loading);
 
-	async function handleCancelInvite(id: string) {
-		await runOptimisticUpdate({
-			apply: () => friendsState.cancelInvite(id),
-			request: () => tryFetch(`/api/invites/${id}`, { method: 'DELETE' }, { shouldParse: false }),
-			revert: ([index, invite]) => friendsState.addInviteAtIndex(index, invite),
-			errorMessage: 'There was a problem canceling the invite. Try again.',
-			toastMessages
-		});
-	}
+	const {
+		cancelInvite: handleCancelInvite,
+		removeFriend,
+		acceptInvite: handleAcceptInvite,
+		rejectInvite: handleRejectInvite
+	} = createFriendsActions(friendsState, toastMessages);
 
 	async function handleRemoveFriend(id: string) {
 		if (!confirm('Are you sure you want to remove this friend?')) {
 			return;
 		}
-		await runOptimisticUpdate({
-			apply: () => friendsState.removeFriend(id),
-			request: () => tryFetch(`/api/friends/${id}`, { method: 'DELETE' }, { shouldParse: false }),
-			revert: ([index, friend]) => friendsState.addFriendAtIndex(index, friend),
-			errorMessage: 'There was a problem removing the friend. Try again.',
-			toastMessages
-		});
+		await removeFriend(id);
 	}
-
-	async function handleAcceptInvite(id: string) {
-		const result = await runOptimisticUpdate({
-			apply: () => friendsState.acceptInvite(id),
-			request: () =>
-				tryFetch(
-					`/api/connections`,
-					{ method: 'POST', body: JSON.stringify({ inviteId: id }) },
-					{ clearQueueOnError: true }
-				),
-			revert: ([index, invite]) => {
-				friendsState.addReceivedInviteAtIndex(index, invite);
-				friendsState.removeFriend(invite.userId);
-			},
-			errorMessage: 'There was a problem removing the friend. Try again.',
-			toastMessages
-		});
-		if (result.type !== 'error') {
-			console.log('accepted invite', result.value);
-		}
-	}
-
-	async function handleRejectInvite(id: string) {
-		await runOptimisticUpdate({
-			apply: () => friendsState.rejectInvite(id),
-			request: () => tryFetch(`/api/friends/accept/${id}`, { method: 'POST' }),
-			revert: ([index, invite]) => friendsState.addReceivedInviteAtIndex(index, invite),
-			errorMessage: 'There was a problem removing the friend. Try again.',
-			toastMessages
-		});
-	}
-
-	type FriendSnippetProps = {
-		name: string;
-		picture?: string | null;
-		showPending: boolean;
-		actions?: Array<{
-			id: string;
-			label: string;
-			icon: LucideIcon;
-			onclick: (id: string) => void;
-		}>;
-	};
 </script>
-
-{#snippet Friend(props: FriendSnippetProps)}
-	<div
-		class="h-friend dark:bg-dark flex w-full items-center justify-between gap-2 p-4"
-		role="listitem"
-		in:fade
-		out:slide={{ duration: 250 }}
-	>
-		<div class="flex items-center gap-2">
-			{#if props.picture}
-				<UserAvatar picture={props.picture} name={props.name} size={8} showTooltip={false} />
-			{/if}
-
-			<div class:italic={props.showPending} class:text-gray-400={props.showPending}>
-				{props.name}
-				{#if props.showPending}
-					<span class="text-xs text-gray-400 italic">(pending)</span>
-				{/if}
-			</div>
-		</div>
-
-		<div class="flex gap-1">
-			{#if props.actions}
-				{#each props.actions as action}
-					{@const ActionIcon = action.icon}
-					<Button
-						variant="ghost"
-						label={action.label}
-						onclick={() => action.onclick(action.id)}
-						tooltip={action.label}
-					>
-						<ActionIcon />
-					</Button>
-				{/each}
-			{/if}
-		</div>
-	</div>
-{/snippet}
 
 <h1 class="text-2xl">Friends</h1>
 <p>Connect with your friends to share notes.</p>
@@ -197,34 +106,34 @@
 						</p>
 					{/if}
 					{#each friendsState.pendingSentInvites as invite (invite.id)}
-						{@render Friend({
-							name: invite.friendEmail,
-							showPending: true,
-							actions: [
+						<FriendListItem
+							name={invite.friendEmail}
+							showPending={true}
+							actions={[
 								{
 									id: invite.id,
 									icon: X,
 									label: 'Cancel',
 									onclick: handleCancelInvite
 								}
-							]
-						})}
+							]}
+						/>
 					{/each}
 
 					{#each friendsState.friends as friend (friend.id)}
-						{@render Friend({
-							name: friend.name!,
-							showPending: false,
-							picture: friend.picture,
-							actions: [
+						<FriendListItem
+							name={friend.name!}
+							showPending={false}
+							picture={friend.picture}
+							actions={[
 								{
 									id: friend.id,
 									icon: X,
 									label: 'Remove',
 									onclick: handleRemoveFriend
 								}
-							]
-						})}
+							]}
+						/>
 					{/each}
 				</div>
 			</Tabs.Content>
@@ -235,11 +144,11 @@
 						<p class="p-4">No incoming invites</p>
 					{:else}
 						{#each friendsState.pendingReceivedInvites as invite (invite.id)}
-							{@render Friend({
-								name: invite.user.name!,
-								picture: invite.user.picture,
-								showPending: false,
-								actions: [
+							<FriendListItem
+								name={invite.user.name!}
+								picture={invite.user.picture}
+								showPending={false}
+								actions={[
 									{
 										id: invite.id,
 										icon: Check,
@@ -252,8 +161,8 @@
 										label: 'Reject',
 										onclick: handleRejectInvite
 									}
-								]
-							})}
+								]}
+							/>
 						{/each}
 					{/if}
 				</div>


### PR DESCRIPTION
## Summary
Extracts orchestration logic out of two components that exceeded the project's 200-line guideline:

- `src/lib/state/boardSync.svelte.ts` — `refreshFromServer` reconcile/retry loop, cache hydration (`hydrateFromCache`), and the two debounced local-cache persistence `$effect`s. `my/+layout.svelte` is now 131 lines (down from 208).
- `src/lib/state/friendsActions.ts` — the 4 optimistic friend/invite handlers (`cancelInvite`, `removeFriend`, `acceptInvite`, `rejectInvite`).
- `src/components/FriendListItem.svelte` — the repeated friend/invite row markup, previously an inline `{#snippet}`. `my/friends/+page.svelte` is now 172 lines (down from 263).

Fixes #777

No behavior changes — purely moving existing logic into dedicated modules so it's usable/testable independent of component markup.

## Test plan
- [x] `pnpm check` / `pnpm lint` / `pnpm format` all clean
- [x] Manually verified via `agent-browser` against the local dev server:
  - Board hydration from IndexedDB cache + server reconciliation still works; edited and saved a note, reloaded, confirmed the change persisted
  - Friends page: seeded a friend + sent/received invite via Prisma, confirmed `FriendListItem` renders correctly for all 3 row types (pending sent, friend, received invite), then exercised cancel invite and accept invite through the extracted `createFriendsActions` — both succeeded with no errors
- [x] `/caveman-review` run on the diff — no bugs found

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>