### PR TITLE
chore: remove leftover debug console.log in acceptInvite

### DIFF
--- a/src/lib/state/friendsActions.ts
+++ b/src/lib/state/friendsActions.ts
@@ -24,7 +24,7 @@ export function createFriendsActions(friendsState: FriendsState, toastMessages: 
 	}
 
 	async function acceptInvite(id: string) {
-		const result = await runOptimisticUpdate({
+		await runOptimisticUpdate({
 			apply: () => friendsState.acceptInvite(id),
 			request: () =>
 				tryFetch(
@@ -39,9 +39,6 @@ export function createFriendsActions(friendsState: FriendsState, toastMessages: 
 			errorMessage: 'There was a problem removing the friend. Try again.',
 			toastMessages
 		});
-		if (result.type !== 'error') {
-			console.log('accepted invite', result.value);
-		}
 	}
 
 	async function rejectInvite(id: string) {


### PR DESCRIPTION
## Summary
Removes the leftover `console.log('accepted invite', result.value)` debug statement from `handleAcceptInvite` (now `acceptInvite` in `src/lib/state/friendsActions.ts` after #776/#805 extracted it out of `friends/+page.svelte`). The `else`/now-dead `result` capture is removed along with it since nothing else used it.

Fixes #779

## Test plan
- [x] `pnpm check` / `pnpm lint` / `pnpm format` clean
- [x] Verified via `agent-browser`: seeded a pending received invite via Prisma, accepted it through the UI, confirmed it still succeeds (invite clears, friend added) and checked the browser console — no `accepted invite` log line
- [x] `/caveman-review` run on the diff — trivial removal, nothing to flag

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>