### PR TITLE
fix: rejecting an invite calls the correct endpoint

### DIFF
--- a/src/lib/state/friendsActions.ts
+++ b/src/lib/state/friendsActions.ts
@@ -44,9 +44,10 @@ export function createFriendsActions(friendsState: FriendsState, toastMessages: 
 	async function rejectInvite(id: string) {
 		await runOptimisticUpdate({
 			apply: () => friendsState.rejectInvite(id),
-			request: () => tryFetch(`/api/friends/accept/${id}`, { method: 'POST' }),
+			request: () =>
+				tryFetch(`/api/invites/${id}/reject`, { method: 'POST' }, { shouldParse: false }),
 			revert: ([index, invite]) => friendsState.addReceivedInviteAtIndex(index, invite),
-			errorMessage: 'There was a problem removing the friend. Try again.',
+			errorMessage: 'There was a problem rejecting the invite. Try again.',
 			toastMessages
 		});
 	}

--- a/src/routes/api/invites/[id]/reject/+server.ts
+++ b/src/routes/api/invites/[id]/reject/+server.ts
@@ -1,0 +1,17 @@
+import { error, type RequestHandler } from '@sveltejs/kit';
+
+import { mapToApiError } from '$lib/server/apiResultMapper';
+import { ignoreInvite } from '$lib/server/services/friendService';
+
+export const POST: RequestHandler = async ({ locals, params }) => {
+	if (!locals.user) {
+		return error(401, { message: 'Unauthorized' });
+	}
+
+	const result = await ignoreInvite(params.id!).mapErr(mapToApiError);
+
+	return result.match(
+		() => new Response(null, { status: 204 }),
+		(err) => error(err.status, { message: err.message })
+	);
+};


### PR DESCRIPTION
## Summary
`handleRejectInvite` posted to `/api/friends/accept/[id]` (a route that doesn't exist), so every reject 404'd and the optimistic UI update just reverted, silently doing nothing.

- Adds `POST /api/invites/[id]/reject`, mirroring the existing `DELETE /api/invites/[id]` handler but calling `ignoreInvite` (already defined in `friendService.ts`, previously unused) instead of `cancelInvite`
- Points `rejectInvite` in `src/lib/state/friendsActions.ts` at the new endpoint
- Fixes the error toast copy, which was the `removeFriend` message pasted in by mistake

Fixes #802

## Test plan
- [x] `pnpm check` / `pnpm lint` / `pnpm format` clean
- [x] Verified via `agent-browser`: seeded a pending received invite via Prisma, clicked Reject, confirmed it clears with no error toast, then did a full page reload and confirmed it stayed cleared (previously it would revert back to pending)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invite rejection so it uses the correct server endpoint.
  * Added proper authentication and error handling for rejected invites.
  * Rejection requests now complete successfully without attempting to parse an empty response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->