### PR TITLE
fix: add fallback initials to UserAvatar for failed image loads

### DIFF
--- a/src/components/UserAvatar.svelte
+++ b/src/components/UserAvatar.svelte
@@ -18,12 +18,26 @@
 		8: 'size-8'
 	};
 
+	function getInitials(fullName: string): string {
+		return fullName
+			.trim()
+			.split(/\s+/)
+			.slice(0, 2)
+			.map((part) => part[0]?.toUpperCase() ?? '')
+			.join('');
+	}
+
 	const imageClass = $derived(`m-0 rounded-full ring-2 ring-white ${sizeMap[size]}`);
+	const fallbackClass = $derived(
+		`bg-secondary m-0 flex items-center justify-center rounded-full text-xs font-medium text-white ring-2 ring-white ${sizeMap[size]}`
+	);
+	const initials = $derived(getInitials(name));
 </script>
 
 {#snippet avatarImage(triggerProps?: Record<string, unknown>)}
-	<Avatar.Root>
-		<Avatar.Image {...triggerProps} src={picture} alt={`Avatar of ${name}`} class={imageClass} />
+	<Avatar.Root {...triggerProps} class="inline-flex {sizeMap[size]}">
+		<Avatar.Image src={picture} alt={`Avatar of ${name}`} class={imageClass} />
+		<Avatar.Fallback class={fallbackClass}>{initials}</Avatar.Fallback>
 	</Avatar.Root>
 {/snippet}
 


### PR DESCRIPTION
## Summary
`UserAvatar.svelte` only rendered `Avatar.Image` — when a picture URL fails to load (broken/expired URL, or no `picture` set), `bits-ui` sets `data-status="error"` and hides the image (`display: none`) with nothing else in the DOM to show, so the avatar renders fully invisible.

- Adds `Avatar.Fallback` showing the user's initials; `bits-ui` toggles its visibility automatically based on load status, no manual state tracking needed
- Moves the `Tooltip.Trigger`'s spread props from `Avatar.Image` to `Avatar.Root` — they were only reaching the (often-hidden) image element, so hovering a fallback avatar wouldn't have shown its tooltip either

Fixes #803

## Test plan
- [x] `pnpm check` / `pnpm lint` / `pnpm format` clean, `svelte-autofixer` clean
- [x] Verified via `agent-browser`: seeded a friend with an unreachable picture URL, confirmed initials ("BF") render in its place at the correct size, and confirmed the tooltip still shows the friend's name on hover over the fallback
- [x] Incidentally reproduced against the real test account too — its Gravatar URL doesn't resolve in this sandbox, so it was rendering invisible before this fix and now correctly shows initials

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>