### PR TITLE
fix: drag-over highlight doesn't suppress correctly for a note's own dropzone

### DIFF
--- a/src/components/Board.svelte
+++ b/src/components/Board.svelte
@@ -60,6 +60,8 @@
 		}
 	}
 
+	let draggedIndex: number | null = $state(null);
+
 	let selectedNoteFriends = $derived(
 		friends.map((f) => {
 			const editor = selectedNote?.editors?.find((e) => e.userId === f.id);
@@ -94,8 +96,16 @@
 	<NoteList>
 		{#each notes as note, index}
 			<NoteContainer>
-				<NoteDropzone {index} ondropped={handleDrop}>
-					<Note {note} {friends} {index} isDraggable={true} onclick={() => handleEdit(note.id)} />
+				<NoteDropzone {index} {draggedIndex} ondropped={handleDrop}>
+					<Note
+						{note}
+						{friends}
+						{index}
+						isDraggable={true}
+						onclick={() => handleEdit(note.id)}
+						ondragstart={(i) => (draggedIndex = i)}
+						ondragend={() => (draggedIndex = null)}
+					/>
 				</NoteDropzone>
 			</NoteContainer>
 		{/each}

--- a/src/components/Note.svelte
+++ b/src/components/Note.svelte
@@ -11,9 +11,19 @@
 		isDraggable?: boolean;
 		friends?: Friend[];
 		onclick: () => void;
+		ondragstart?: (index: number) => void;
+		ondragend?: () => void;
 	};
 
-	let { note, index, friends = [], isDraggable = true, onclick }: Props = $props();
+	let {
+		note,
+		index,
+		friends = [],
+		isDraggable = true,
+		onclick,
+		ondragstart,
+		ondragend
+	}: Props = $props();
 	let isDragging = $state(false);
 	let isHovering = $state(false);
 	let editors = $derived(
@@ -29,10 +39,12 @@
 	function handleDragStart(event: DragEvent) {
 		event.dataTransfer?.setData('text/plain', index.toString());
 		isDragging = true;
+		ondragstart?.(index);
 	}
 
 	function handleDragEnd() {
 		isDragging = false;
+		ondragend?.();
 	}
 </script>
 

--- a/src/components/NoteDropzone.svelte
+++ b/src/components/NoteDropzone.svelte
@@ -4,10 +4,11 @@
 	type Props = {
 		children: Snippet<[]>;
 		index: number;
+		draggedIndex?: number | null;
 		ondropped: (toIndex: number, sourceIndex: number) => void;
 	};
 
-	let { children, index, ondropped }: Props = $props();
+	let { children, index, draggedIndex = null, ondropped }: Props = $props();
 
 	let dragOverDepth = $state(0);
 
@@ -15,18 +16,20 @@
 		event.preventDefault();
 	}
 
+	// dataTransfer.getData() is only readable during `dragstart`/`drop` - browsers
+	// return an empty string during dragenter/dragleave/dragover, so the dragged
+	// item's index has to come from draggedIndex (tracked by the parent via
+	// Note's ondragstart/ondragend) instead of the DragEvent itself.
 	function handleDragEnter(event: DragEvent) {
 		event.preventDefault();
-		const sourceIndex = parseInt(event.dataTransfer?.getData('text/plain') ?? '');
-		if (sourceIndex !== index) {
+		if (draggedIndex !== index) {
 			dragOverDepth += 1;
 		}
 	}
 
 	function handleDragLeave(event: DragEvent) {
 		event.preventDefault();
-		const sourceIndex = parseInt(event.dataTransfer?.getData('text/plain') ?? '');
-		if (sourceIndex !== index) {
+		if (draggedIndex !== index) {
 			dragOverDepth -= 1;
 		}
 	}


### PR DESCRIPTION
## Summary
Issue #259 reported drag-and-drop ordering issues around the last item, with no further description. I couldn't reproduce a data/ordering bug — ran first↔last, middle→last, and second-to-last→last reorders (the last one crossing a flex-wrap row boundary, since the 5th note sits alone on its own row at desktop width) and every case produced the correct final order, persisted correctly after a full reload.

What I did find: `NoteDropzone.svelte`'s `handleDragEnter`/`handleDragLeave` read `event.dataTransfer.getData()` to check whether the hovered dropzone is the dragged note's own source position. Per the HTML5 DnD spec, `getData()` only returns real data during `dragstart`/`drop` — during `dragenter`/`dragleave`/`dragover` browsers return an empty string, so `sourceIndex` was always `NaN` and the "don't highlight my own source item" check never worked. This doesn't corrupt ordering, but can leave the dashed "drop guide" placeholder stuck visible instead of the note.

Fix: track the dragged note's index as state in `Board.svelte` (set via `Note`'s new `ondragstart`/`ondragend` callbacks) and pass it down to `NoteDropzone` as a prop, instead of relying on `dataTransfer` outside of `drop`.

Fixes #259

## Test plan
- [x] `pnpm check` / `pnpm lint` / `pnpm format` clean
- [x] Verified via `agent-browser`: re-ran the full set of reorder scenarios end-to-end (first→last, last→first) — still correct and persisted after reload
- [x] Verified the fix directly with synthetic drag events: entering a note's own dropzone no longer shows the drop guide (previously always did), entering a different note's dropzone still shows it correctly
- [x] `/caveman-review` run on the diff — no bugs found

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved drag-and-drop note reordering with more precise drop-zone highlighting.
  - Added support for tracking when a note starts and finishes dragging.

- **Bug Fixes**
  - Prevented the active note’s own drop zone from being incorrectly highlighted during dragging.
  - Improved drag state handling as notes move across drop zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->