### PR TITLE
fix: logout link causes a client-side 404 console error before completing

### DIFF
--- a/src/components/ProfileMenu.svelte
+++ b/src/components/ProfileMenu.svelte
@@ -17,12 +17,20 @@
 		href: string;
 		text: string;
 		borderTop?: boolean;
+		reload?: boolean;
 		icon: LucideIcon;
 		itemProps: Record<string, unknown>;
 	};
 </script>
 
-{#snippet MenuLink({ borderTop = false, href, icon: Icon, text, itemProps }: MenuLinkProps)}
+{#snippet MenuLink({
+	borderTop = false,
+	href,
+	icon: Icon,
+	text,
+	itemProps,
+	reload = false
+}: MenuLinkProps)}
 	{#if borderTop}
 		<div class="dark:border-dark-border mt-2 border-t border-gray-200"></div>
 	{/if}
@@ -30,6 +38,7 @@
 		{...itemProps}
 		class="hover:bg-slate hover:bg-background dark:hover:bg-dark-hover mt-2 flex w-full gap-2 rounded-lg p-2"
 		{href}
+		data-sveltekit-reload={reload ? true : undefined}
 	>
 		<Icon />
 		<span>{text}</span>
@@ -74,6 +83,7 @@
 										href: '/api/auth/logout',
 										icon: LogOut,
 										borderTop: true,
+										reload: true,
 										itemProps
 									})}
 								{/snippet}


### PR DESCRIPTION
## Summary
`ProfileMenu.svelte`'s Logout link is a plain `<a href="/api/auth/logout">`. SvelteKit progressively enhances same-origin `<a>` tags for client-side navigation by default, but `/api/auth/logout` is a `+server.ts` API route, not a page — the router logs a 404 before falling through to a real full-page navigation, which is what actually completes the logout.

Adds a `reload` prop to the shared `MenuLink` snippet, set only on the Logout item, rendering `data-sveltekit-reload` so that link always does a normal full-page navigation. "Account settings" is untouched and keeps client-side navigation.

Fixes #795

## Test plan
- [x] `pnpm check` / `pnpm lint` / `pnpm format` clean
- [x] Verified via `agent-browser`: confirmed `data-sveltekit-reload="true"` is present on the rendered Logout `<a>`, clicked it, and confirmed no 404/"Not Found" error in the console while logout still completes correctly

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>