### PR TITLE
fix: cards on the board are missing avatar icons (#814)

### DIFF
--- a/src/components/UserAvatar.svelte
+++ b/src/components/UserAvatar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Avatar, Tooltip } from 'bits-ui';
+	import { Tooltip } from 'bits-ui';
 
 	type Props = {
 		picture: string;
@@ -32,13 +32,25 @@
 		`bg-secondary m-0 flex items-center justify-center rounded-full text-xs font-medium text-white ring-2 ring-white ${sizeMap[size]}`
 	);
 	const initials = $derived(getInitials(name));
+
+	// Tracks the src that failed rather than a boolean, so a new picture is
+	// retried instead of staying stuck on the fallback.
+	let failedSrc = $state<string | null>(null);
+	const showFallback = $derived(!picture || failedSrc === picture);
+
+	function handleImageError() {
+		failedSrc = picture;
+	}
 </script>
 
 {#snippet avatarImage(triggerProps?: Record<string, unknown>)}
-	<Avatar.Root {...triggerProps} class="inline-flex {sizeMap[size]}">
-		<Avatar.Image src={picture} alt={`Avatar of ${name}`} class={imageClass} />
-		<Avatar.Fallback class={fallbackClass}>{initials}</Avatar.Fallback>
-	</Avatar.Root>
+	<span {...triggerProps} class="inline-flex {sizeMap[size]}">
+		{#if showFallback}
+			<span class={fallbackClass} aria-label={`Avatar of ${name}`} role="img">{initials}</span>
+		{:else}
+			<img src={picture} alt={`Avatar of ${name}`} class={imageClass} onerror={handleImageError} />
+		{/if}
+	</span>
 {/snippet}
 
 {#if showTooltip}


### PR DESCRIPTION
Fixes #814.

## What went wrong

The bits-ui migration (#780) swapped `<img src>` for `Avatar.Root`/`Avatar.Image`. That is not a cosmetic swap: bits-ui does **not** let the browser render the image. `AvatarRootState.loadImage()` preloads the URL with `new Image()` and `AvatarImageState` renders `style="display: none"` until that preload fires `onload`. Any status other than `loaded` means an invisible avatar.

Between #780 and #809 there was no `Avatar.Fallback` either, so an avatar whose preload never completed rendered literally nothing — which matches the screenshot on the issue exactly: the `bg-white/20 backdrop-blur-xs` strip in `Note.svelte` renders (so `note.shared || editors.length > 0` passes and the data is fine), it is just empty.

## The fix

Drop `Avatar` and render the `<img>` directly, falling back to initials on `onerror` or a missing `picture`. bits-ui's Avatar bought nothing here except the hide-until-preloaded behaviour that caused the regression. There is no longer any state in which an avatar renders as nothing, whatever the underlying image URLs do.

- `failedSrc` stores the URL that failed rather than a boolean flag, so if `picture` later changes to a working URL the image is retried instead of staying stuck on initials.
- The fallback span carries `role="img"` + `aria-label`, so the avatar keeps an accessible name in both states.
- The bits-ui `Tooltip` is unchanged; the trigger props now land on the wrapper `<span>`.

## Verification

Rendered the component in a scratch route across all three states:

| state | result |
| --- | --- |
| valid `picture` | 20px image, tooltip opens with the right text |
| broken `picture` | teal initials circle |
| empty `picture` | teal initials circle, no request |
| broken → valid | recovers to the image |

Also confirmed beforehand that the tooltip `child`-snippet path, the `prose`/`absolute`/`backdrop-blur` card context, and the unkeyed `{#each}` were not at fault — 12 board cards with late-arriving friends and array reorders all reported `data-status="loaded"` in both dev and a production build, and `size-5`/`bg-secondary` are present in the deployed CSS.

`pnpm check` passes with 0 errors (the 8 warnings are pre-existing in `NoteEditor.svelte`, `LinkButton.svelte` and `my/+layout.svelte`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar image error handling so a fallback is shown only for the specific image that fails to load.
  * Preserved initials-based avatars when no valid profile image is available.
  * Maintained existing avatar tooltip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->