### PR TITLE
feat: show success toast on note create, update, and delete

### DIFF
--- a/src/lib/browserFetch.ts
+++ b/src/lib/browserFetch.ts
@@ -134,17 +134,20 @@ interface OptimisticUpdateParams<TApplied, TResult extends Result<unknown>> {
 	request: (applied: TApplied) => Promise<TResult>;
 	revert: (applied: TApplied) => void;
 	errorMessage: string;
+	successMessage?: string;
 	toastMessages: ToastMessages;
 }
 
 // Runs an optimistic local mutation, then reverts it and shows a toast if the
-// matching request fails. Returns the request result so callers can layer
-// extra success-only behaviour (e.g. navigation) on top.
+// matching request fails, or shows a success toast if one was requested.
+// Returns the request result so callers can layer extra success-only
+// behaviour (e.g. navigation) on top.
 export async function runOptimisticUpdate<TApplied, TResult extends Result<unknown>>({
 	apply,
 	request,
 	revert,
 	errorMessage,
+	successMessage,
 	toastMessages
 }: OptimisticUpdateParams<TApplied, TResult>): Promise<TResult> {
 	const applied = apply();
@@ -154,6 +157,9 @@ export async function runOptimisticUpdate<TApplied, TResult extends Result<unkno
 		revert(applied);
 		const errorMessageValue: ToastMessage = { type: 'error', message: errorMessage };
 		toastMessages.addMessage(errorMessageValue);
+	} else if (successMessage) {
+		const successMessageValue: ToastMessage = { type: 'success', message: successMessage };
+		toastMessages.addMessage(successMessageValue);
 	}
 
 	return result;

--- a/src/routes/my/+layout.svelte
+++ b/src/routes/my/+layout.svelte
@@ -90,6 +90,8 @@
 				type: 'error',
 				message: 'There was a problem creating a note. Try again.'
 			});
+		} else {
+			toastMessages.addMessage({ type: 'success', message: 'Note created' });
 		}
 	}
 </script>

--- a/src/routes/my/board/+page.svelte
+++ b/src/routes/my/board/+page.svelte
@@ -70,6 +70,7 @@
 				}),
 			revert: ([, original]) => boardState.updateNote(original),
 			errorMessage: 'Failed to update note. Try again.',
+			successMessage: 'Note updated',
 			toastMessages
 		});
 	}
@@ -81,6 +82,7 @@
 				tryFetch(`/api/notes/${note.id}`, { method: 'DELETE' }, { shouldParse: false }),
 			revert: ([deletedNote, index]) => boardState.createNoteAtIndex(index, deletedNote),
 			errorMessage: 'Failed to delete note. Try again.',
+			successMessage: 'Note deleted',
 			toastMessages
 		});
 		if (result.type !== 'error') {

--- a/tests/noteManagement.test.ts
+++ b/tests/noteManagement.test.ts
@@ -20,6 +20,9 @@ test('basic note management', async ({ page }) => {
 	// Click the create button - the queue will handle request sequencing
 	await createButton.click();
 
+	// Verify the success toast appears once the note is created on the server
+	await expect(page.getByText('Note created')).toBeVisible();
+
 	await page.getByRole('button', { name: 'Choose colour' }).click();
 	await page.getByRole('button', { name: 'blue' }).click();
 
@@ -32,6 +35,9 @@ test('basic note management', async ({ page }) => {
 	await editor.fill(noteContent);
 
 	await page.getByRole('button', { name: 'Save note' }).click();
+
+	// Verify the success toast appears once the note is updated on the server
+	await expect(page.getByText('Note updated')).toBeVisible();
 
 	// Wait for the note to be saved - verify the note appears on the board
 	await expect(page.getByText(noteTitle)).toBeVisible();
@@ -55,6 +61,9 @@ test('basic note management', async ({ page }) => {
 
 	await page.getByRole('button', { name: 'Delete note' }).click();
 	await deleteNotePromise;
+
+	// Verify the success toast appears once the note is deleted on the server
+	await expect(page.getByText('Note deleted')).toBeVisible();
 
 	// Verify the note content is no longer visible on the page
 	await expect(page.getByText(noteTitle)).not.toBeVisible();


### PR DESCRIPTION
## Summary
- Extend `runOptimisticUpdate` with an optional `successMessage` so note update/delete show a green success toast once the server confirms the change
- Wire a success toast into note create directly (it doesn't go through the optimistic-update helper)
- Extend `noteManagement.test.ts` to assert each toast ("Note created" / "Note updated" / "Note deleted") appears

## Test plan
- [x] `pnpm check` passes with no new errors
- [x] `pnpm exec playwright test tests/noteManagement.test.ts` passes, asserting all three toasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1tdpzRboY4mSzwsP5uG9m