### PR TITLE
fix: keep success toast clear of the mobile bottom nav

### DIFF
--- a/src/components/Toaster.svelte
+++ b/src/components/Toaster.svelte
@@ -2,4 +2,4 @@
 	import { Toaster as SonnerToaster } from 'svelte-sonner';
 </script>
 
-<SonnerToaster position="bottom-center" richColors />
+<SonnerToaster position="bottom-center" richColors mobileOffset={{ bottom: '5rem' }} />

--- a/tests/noteManagement.test.ts
+++ b/tests/noteManagement.test.ts
@@ -36,8 +36,10 @@ test('basic note management', async ({ page }) => {
 
 	await page.getByRole('button', { name: 'Save note' }).click();
 
-	// Verify the success toast appears once the note is updated on the server
-	await expect(page.getByText('Note updated')).toBeVisible();
+	// Verify the success toast appears once the note is updated on the server.
+	// The colour change earlier in this test may have left its own "Note
+	// updated" toast still on screen, so target the most recent one.
+	await expect(page.getByText('Note updated').last()).toBeVisible();
 
 	// Wait for the note to be saved - verify the note appears on the board
 	await expect(page.getByText(noteTitle)).toBeVisible();


### PR DESCRIPTION
## Summary
- On mobile, the "Note created/updated/deleted" toast sat directly on top of the fixed bottom nav bar (see screenshot from testing on device). Uses svelte-sonner's `mobileOffset` to lift the toast 5rem from the bottom on small screens, clearing the 4rem nav bar with a small gap.
- Desktop keeps its existing `bottom-center` placement — verified there's no fixed bottom UI there for it to collide with.
- Fixes a related test flake: choosing a note colour also fires an update toast, so the assertion on the Save button's toast could match two "Note updated" elements if both were still on screen; now targets the most recent one.

## Test plan
- [x] `pnpm check` passes with no new errors
- [x] `pnpm exec playwright test tests/noteManagement.test.ts` passes
- [x] Manually verified via mobile device emulation (iPhone 14) that create/update/delete toasts now sit above the bottom nav
- [x] Manually verified desktop (1440x900) placement is unaffected and doesn't overlap any content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1tdpzRboY4mSzwsP5uG9m