### PR TITLE
fix: keep note avatars inside the shared-note strip

### DIFF
--- a/src/components/Note.svelte
+++ b/src/components/Note.svelte
@@ -80,7 +80,7 @@
 
 	{#if note.shared || editors.length > 0}
 		<div
-			class="absolute bottom-0 left-0 flex h-10 w-full items-center gap-2 bg-white/20 px-4 backdrop-blur-xs"
+			class="not-prose absolute bottom-0 left-0 flex h-10 w-full items-center gap-2 bg-white/20 px-4 backdrop-blur-xs"
 		>
 			{#if note.shared}
 				<UserAvatar picture={note.owner.picture || ''} name={note.owner.name || ''} />


### PR DESCRIPTION
## Summary
- Shared/collaborator note cards show a translucent strip at the bottom with owner/editor avatars — on the board these avatars were rendering mostly cut off by the card's `overflow-hidden`, instead of centered in the strip.
- Root cause: the note card carries Tailwind Typography's `prose` class (to style the note body HTML). In Tailwind v4, `@tailwindcss/typography`'s default `img` styles aren't cascade-layered, so its 28px top/bottom `img` margin overrides the avatar's own `m-0` utility regardless of specificity — pushing the avatar image ~28px down and clipping most of it.
- Fix: add `not-prose` to the avatar strip's container, opting it out of Typography styling entirely (Typography's own documented escape hatch), rather than trying to out-specificity/`!important` the plugin.

Verified by injecting the real component markup into a live Playwright-driven session (against the app's actual compiled CSS): before the fix `img` had `margin-top/bottom: 28px` and rendered below the visible strip; after, margins are `0px` and both photo and initials-fallback avatars sit centered inside it.

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm format` — no changes needed
- [x] Verified avatar centering against real compiled Tailwind CSS via Playwright (photo avatar + initials-fallback avatar both confirmed centered post-fix)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHLGgHgYvVPLDKMGVTHfnL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the display of shared and editing avatars by preventing surrounding prose styles from affecting the overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->