### PR TITLE
feat: System / Light / Dark theme switcher (#828)

### DIFF
--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -178,51 +178,72 @@ surfaces plus `--color-line`**. The tokens swap; components don't change.
 ## 4. Dark mode and theming
 
 The token layer defines a **complete dark ramp** — neutrals, accent, semantic, all six note
-colours, and shadows. Dark mode is not missing; what's missing is user control over it.
+colours, and shadows. The app supports three states: **System / Light / Dark**, with System
+the default.
 
-### Current behaviour
+### How the three states resolve
 
-The app has **no theme switcher**. `app.css` never declares `@custom-variant dark`, so
-Tailwind v4's default applies and every `dark:` utility compiles to
-`@media (prefers-color-scheme: dark)`. Theme follows the OS and cannot be overridden.
+`data-theme` on `<html>` carries an explicit choice. **System stamps nothing** — the absent
+attribute is the signal, and `prefers-color-scheme` does the rest in pure CSS.
 
-### Required change to support a switcher
+| State  | `data-theme` | Resolves via                                            |
+| ------ | ------------ | ------------------------------------------------------- |
+| System | absent       | `@media (prefers-color-scheme: dark)`                   |
+| Light  | `light`      | `:not([data-theme='light'])` excludes it from the query |
+| Dark   | `dark`       | the attribute selector                                  |
+
+Leaving System attribute-less buys two things: it cannot flash (no JS decides it), and it
+keeps following the OS while the page is open with no `matchMedia` listener.
+
+### The dark variant
 
 This is a **design-system-level decision**, because it changes how every `dark:` utility in
-the codebase resolves:
+the codebase resolves. It must match **both** conditions, mirroring how the tokens
+themselves are scoped:
 
 ```css
 /* app.css */
-@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+@custom-variant dark {
+	&:where([data-theme='dark'], [data-theme='dark'] *) {
+		@slot;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		&:where(:root:not([data-theme='light']), :root:not([data-theme='light']) *) {
+			@slot;
+		}
+	}
+}
 ```
 
-Then `data-theme` is stamped on `<html>` and the app supports three states —
-**System / Light / Dark** — with `System` as the default so current behaviour is preserved
-for anyone who never opens the setting.
+**Tailwind's documented one-liner —
+`@custom-variant dark (&:where([data-theme='dark'], [data-theme='dark'] *))` — is wrong
+here.** It resolves `dark:` on the attribute only, so in System mode on a dark OS the tokens
+flip from the media query while every `dark:` utility stays light: dark chrome, light note
+pastels. Keep the variant and the token block in step, condition for condition.
 
-`tokens.css` already applies the dark palette under **both** the media query and
-`:root[data-theme='dark']`, and scopes the media query with `:not([data-theme='light'])` so
-an explicit light choice wins over a dark OS. The token file therefore needs no change when
-the switcher lands — only `app.css` gains the `@custom-variant` line above.
+### Rules for whoever touches this
 
-Implementation notes for whoever picks this up:
-
-- Needs a blocking inline script in `src/app.html` that reads `localStorage` and sets the
-  attribute **before first paint**, or the page flashes the wrong theme on load.
-- `src/components/Menu.svelte` has a `@media (prefers-color-scheme: dark)` block in its
-  scoped `<style>`. Media queries do not respond to an attribute toggle, so that block must
-  move to tokens or to a `dark:` utility, or the nav will disagree with the rest of the app.
-- `color-scheme` is already wired in `tokens.css` §10 for all three states, so native form
-  controls and scrollbars follow the toggle rather than only the OS. Nothing in the app sets
-  it today.
-- The manifest's `theme_color` is a single static value and can't follow the toggle; leave
-  it on the light brand colour.
+- **A colour that must change with the theme belongs in a token, not a `dark:` utility.**
+  Tokens flip once, centrally. `dark:` is for the handful of cases with no token — the note
+  pastels (`dark:bg-note-*-dark`) and `dark:prose-invert`.
+- **Never put `@media (prefers-color-scheme: dark)` in a component's scoped `<style>`.** A
+  media query does not respond to the attribute, so that component silently disagrees with
+  the rest of the app in explicit Light or Dark.
+- The pre-paint script in `src/app.html` must stay **blocking and inline**, before
+  `%sveltekit.head%`. Deferred or bundled runs too late and the wrong theme paints first.
+  It mirrors `themeStorageKey` and `themeAttribute` in `src/lib/theme.ts` by hand — it
+  cannot import — so change both together.
+- `color-scheme` is wired in §10 for all three states, so native form controls and
+  scrollbars follow the choice rather than only the OS.
+- The manifest's `theme_color` is a single static value and can't follow the toggle; it
+  stays on the light brand colour.
 
 ### Where the switcher lives
 
 The **variant strategy above belongs to the design system.** The switcher **UI** is a
-product feature and belongs in `/my/account` alongside the display-name form — build it as
-its own piece of work, not as part of a token migration.
+product feature: `src/components/ThemeSwitcher.svelte`, rendered in `/my/account` alongside
+the display-name form.
 
 ---
 
@@ -295,6 +316,12 @@ bounces.
 
 Durations: `--duration-tap` 100ms · `--duration-fast` 160ms · `--duration-base` 240ms ·
 `--duration-slow` 360ms · `--duration-sheet` 420ms.
+
+**Write durations as `duration-(--duration-fast)`, not `duration-fast`.** `--ease-*` is a
+Tailwind theme namespace, so `ease-move` compiles; `--duration-*` is **not**, so
+`duration-fast` matches no utility and Tailwind silently emits nothing. The parenthesis
+form resolves to `transition-duration: var(--duration-fast)`. The square-bracket form
+(`duration-[--duration-fast]`) is also wrong — it emits the raw text, not a `var()`.
 
 ### Choreography
 

--- a/src/app.html
+++ b/src/app.html
@@ -6,6 +6,28 @@
 		<link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png" />
 		<link rel="manifest" href="%sveltekit.assets%/manifest.json" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<!--
+			Stamps an explicit theme choice before first paint, so a stored Light
+			or Dark never flashes the other one on load. Must stay blocking and
+			inline — a deferred or bundled script runs too late.
+
+			"System" stores nothing and needs no attribute: app.css resolves it
+			from prefers-color-scheme, so it cannot flash at all.
+
+			The key and attribute mirror themeStorageKey and themeAttribute in
+			src/lib/theme.ts. Storage throws in Safari private browsing, and an
+			uncaught throw here would block the rest of the head.
+		-->
+		<script>
+			try {
+				const storedTheme = localStorage.getItem('notes:theme');
+				if (storedTheme === 'light' || storedTheme === 'dark') {
+					document.documentElement.setAttribute('data-theme', storedTheme);
+				}
+			} catch {
+				/* no stored preference is recoverable — fall through to System */
+			}
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover" class="bg-canvas text-ink">

--- a/src/components/ThemeSwitcher.svelte
+++ b/src/components/ThemeSwitcher.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { RadioGroup } from 'bits-ui';
+	import { Monitor, Moon, Sun } from '@lucide/svelte';
+
+	import {
+		applyThemePreference,
+		readThemePreference,
+		resolveThemePreference,
+		type ThemePreference
+	} from '$lib/theme';
+
+	type ThemeOption = {
+		value: ThemePreference;
+		label: string;
+		icon: typeof Monitor;
+	};
+
+	const labelId = 'theme-preference-label';
+	const iconSize = 20;
+
+	const themeOptionsValue: ThemeOption[] = [
+		{ value: 'system', label: 'System', icon: Monitor },
+		{ value: 'light', label: 'Light', icon: Sun },
+		{ value: 'dark', label: 'Dark', icon: Moon }
+	];
+
+	/*
+	 * Reads as System during SSR — the stored choice only exists in the
+	 * browser — then corrects itself on hydration. The theme itself is
+	 * already right by then: the pre-paint script in app.html stamped it.
+	 */
+	let preference = $state<ThemePreference>(readThemePreference());
+
+	function handleValueChange(value: string) {
+		preference = resolveThemePreference(value);
+		applyThemePreference(preference);
+	}
+</script>
+
+<div class="mt-8 flex w-full flex-col gap-2 lg:w-1/2">
+	<h2 id={labelId} class="text-heading">Theme</h2>
+	<p class="text-ink-muted text-small">
+		System follows your device. A choice is remembered on this device only.
+	</p>
+
+	<RadioGroup.Root
+		value={preference}
+		onValueChange={handleValueChange}
+		orientation="horizontal"
+		aria-labelledby={labelId}
+		class="border-line bg-paper rounded-control mt-2 inline-flex gap-1 self-start border p-1"
+	>
+		{#each themeOptionsValue as option (option.value)}
+			{@const Icon = option.icon}
+			<RadioGroup.Item
+				value={option.value}
+				class="rounded-chip ease-move flex min-h-11 min-w-11 items-center justify-center gap-2 px-4 py-2 transition-colors duration-(--duration-fast) {preference ===
+				option.value
+					? 'bg-accent text-on-accent'
+					: 'text-ink-muted hover:bg-accent-soft hover:text-accent-strong'}"
+			>
+				<Icon size={iconSize} />
+				{option.label}
+			</RadioGroup.Item>
+		{/each}
+	</RadioGroup.Root>
+</div>

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from 'vitest';
+
+import { resolveThemePreference } from './theme';
+
+describe('resolveThemePreference', () => {
+	test('keeps a recognised preference', () => {
+		expect(resolveThemePreference('light')).toBe('light');
+		expect(resolveThemePreference('dark')).toBe('dark');
+		expect(resolveThemePreference('system')).toBe('system');
+	});
+
+	test('falls back to system when nothing is stored', () => {
+		expect(resolveThemePreference(null)).toBe('system');
+	});
+
+	test('falls back to system for an unrecognised value', () => {
+		expect(resolveThemePreference('sepia')).toBe('system');
+		expect(resolveThemePreference('')).toBe('system');
+	});
+
+	test('does not treat inherited Object properties as preferences', () => {
+		expect(resolveThemePreference('toString')).toBe('system');
+		expect(resolveThemePreference('constructor')).toBe('system');
+	});
+});

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,66 @@
+export const themePreferences = ['system', 'light', 'dark'] as const;
+
+export type ThemePreference = (typeof themePreferences)[number];
+
+/*
+ * Both mirrored by the pre-paint script in src/app.html, which cannot import
+ * from here. Change one, change the other.
+ */
+export const themeStorageKey = 'notes:theme';
+export const themeAttribute = 'data-theme';
+
+const knownPreferences: ReadonlySet<string> = new Set(themePreferences);
+
+const isThemePreference = (value: string): value is ThemePreference => knownPreferences.has(value);
+
+/**
+ * Anything unrecognised — absent, stale, or hand-edited — falls back to
+ * System, which is also the default for anyone who never opens the setting.
+ */
+export const resolveThemePreference = (stored: string | null): ThemePreference =>
+	stored !== null && isThemePreference(stored) ? stored : 'system';
+
+const hasDom = () => typeof document !== 'undefined';
+
+export function readThemePreference(): ThemePreference {
+	if (!hasDom()) {
+		return 'system';
+	}
+
+	try {
+		return resolveThemePreference(localStorage.getItem(themeStorageKey));
+	} catch {
+		return 'system';
+	}
+}
+
+/**
+ * System deliberately clears the attribute rather than resolving the OS
+ * preference to a concrete value: leaving it off lets the media query in
+ * app.css do the work, so the theme keeps following the OS while the page is
+ * open without a matchMedia listener.
+ *
+ * The attribute is stamped before persisting, so a storage failure still
+ * changes the theme for this session instead of appearing to do nothing.
+ */
+export function applyThemePreference(preference: ThemePreference): void {
+	if (!hasDom()) {
+		return;
+	}
+
+	if (preference === 'system') {
+		document.documentElement.removeAttribute(themeAttribute);
+	} else {
+		document.documentElement.setAttribute(themeAttribute, preference);
+	}
+
+	try {
+		if (preference === 'system') {
+			localStorage.removeItem(themeStorageKey);
+		} else {
+			localStorage.setItem(themeStorageKey, preference);
+		}
+	} catch {
+		/* private browsing and full quotas both throw; the theme still applied */
+	}
+}

--- a/src/routes/app.css
+++ b/src/routes/app.css
@@ -15,6 +15,30 @@
 @source not '../../.claude';
 
 /*
+ * Dark variant. Mirrors exactly how the token block below is scoped, so a
+ * `dark:` utility and a token always agree about which theme is in effect.
+ *
+ * Matching only [data-theme='dark'] — Tailwind's documented data-attribute
+ * recipe — would break System mode: the tokens would flip from the media
+ * query while every `dark:` utility stayed light, giving dark chrome with
+ * light note pastels. Covering both conditions means System needs no
+ * attribute at all, so it resolves in pure CSS and can never flash.
+ *
+ * :not([data-theme='light']) lets an explicit light choice beat a dark OS.
+ */
+@custom-variant dark {
+	&:where([data-theme='dark'], [data-theme='dark'] *) {
+		@slot;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		&:where(:root:not([data-theme='light']), :root:not([data-theme='light']) *) {
+			@slot;
+		}
+	}
+}
+
+/*
  * Design system tokens — see docs/design-system/README.md for the rules and
  * rationale, and docs/design-system/preview.html for the visual reference.
  *
@@ -149,10 +173,10 @@
 }
 
 /*
- * Dark mode. Applied under both the media query and [data-theme='dark'] so
- * the theme switcher (#828) needs no token changes — it only has to declare
- * `@custom-variant dark` and stamp the attribute. The media query is scoped
- * with :not([data-theme='light']) so an explicit light choice wins.
+ * Dark mode. Applied under both the media query and [data-theme='dark'],
+ * scoped to match the `dark` variant above condition for condition. Keep the
+ * two in step: a token that flips under a condition the variant doesn't
+ * recognise gives a half-themed screen rather than an error.
  *
  * Elevation is carried by lighter surfaces here because shadow barely reads.
  */

--- a/src/routes/my/account/+page.svelte
+++ b/src/routes/my/account/+page.svelte
@@ -7,6 +7,7 @@
 	import Input from '$components/Input.svelte';
 	import Button from '$components/Button.svelte';
 	import Label from '$components/Label.svelte';
+	import ThemeSwitcher from '$components/ThemeSwitcher.svelte';
 	import { getToastMessages } from '$lib/state/toastMessages.svelte';
 	import { getUserState } from '$lib/state/userState.svelte';
 
@@ -74,3 +75,5 @@
 		</div>
 	</div>
 </form>
+
+<ThemeSwitcher />


### PR DESCRIPTION
Closes #828. Also closes #67, which asked for the same thing.

The dark palette has been complete since the token layer landed — what was missing was any way to choose it. Tailwind's default `dark:` variant compiles to `@media (prefers-color-scheme: dark)`, so the theme followed the OS and couldn't be overridden.

## How the three states resolve

`data-theme` on `<html>` carries an explicit choice. **System stamps nothing** — the absent attribute is the signal.

| State  | `data-theme` | Resolves via |
| ------ | ------------ | ------------ |
| System | absent       | `@media (prefers-color-scheme: dark)` |
| Light  | `light`      | `:not([data-theme='light'])` excludes it from the query |
| Dark   | `dark`       | the attribute selector |

Leaving System attribute-less buys two things: it can't flash, because no JS decides it; and it keeps following the OS while the page is open with no `matchMedia` listener.

## One deliberate deviation from the issue

The issue prescribes Tailwind's documented one-liner:

```css
@custom-variant dark (&:where([data-theme='dark'], [data-theme='dark'] *));
```

**That's wrong here.** It resolves `dark:` on the attribute alone, while the tokens still flip from the media query — so in System mode on a dark OS you'd get dark chrome with *light* note pastels. The variant has to match both conditions, mirroring exactly how the token block is scoped:

```css
@custom-variant dark {
	&:where([data-theme='dark'], [data-theme='dark'] *) { @slot; }

	@media (prefers-color-scheme: dark) {
		&:where(:root:not([data-theme='light']), :root:not([data-theme='light']) *) { @slot; }
	}
}
```

Verified against the built CSS: both branches emit, the media-query branch is correctly wrapped, and the variant rules still come after the base utilities so they win on order (`:where()` keeps specificity at zero).

## Stale warnings in the issue

- `Menu.svelte`'s `@media (prefers-color-scheme: dark)` block — **already gone**, removed when #830 landed. `app.css` is now the only `prefers-color-scheme` in `src/`.
- Only 15 `dark:` usages app-wide, so the visual pass was small.

## Unrelated finding worth acting on before #829

`--duration-*` is **not** a Tailwind theme namespace. `duration-fast` matches no utility and Tailwind silently emits nothing — exactly the failure mode the design-system skill warns about. `--ease-*` *is* a namespace, so `ease-move` works, which makes the asymmetry easy to miss. Durations must be written `duration-(--duration-fast)`. Documented in README §7; #829 would otherwise have hit this on every component.

## Verified

| | |
| --- | --- |
| System on light OS | light ✅ |
| System on dark OS | dark chrome **and** dark note pastels ✅ |
| Explicit Light on dark OS | stays light across a full reload ✅ |
| Explicit Dark on light OS | stays dark ✅ |
| Persistence | `localStorage` survives reload ✅ |
| `color-scheme` | follows the choice (`light` on a dark OS) ✅ |
| Screens | board, account, friends, note editor, privacy (`prose dark:prose-invert`) ✅ |
| Nav indicator | matches the app in every state ✅ |
| Keyboard | arrow keys move and select; focus ring is `--color-accent-ring` ✅ |
| Targets | 44px minimum; container `rounded-control` ≥ children `rounded-chip` ✅ |
| Mobile | 390px ✅ |

`pnpm check` 0 errors · `pnpm lint` clean · 86 unit tests pass.

## Not covered

No Playwright test for the switcher — happy to add one if you'd like it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHLGgHgYvVPLDKMGVTHfnL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a theme preference switcher with System, Light, and Dark options in account settings.
  * Theme selection is applied immediately and saved for future visits.
  * The saved theme is restored before the page first renders to reduce visual flicker.
  * Added safe fallback behavior when theme preferences cannot be stored.

* **Documentation**
  * Updated dark mode and motion guidance with theming and transition syntax details.

* **Tests**
  * Added coverage for valid, missing, and invalid theme preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->