### PR TITLE
fix: stop shared-note avatars squashing on narrow cards

### DIFF
--- a/src/components/Note.svelte
+++ b/src/components/Note.svelte
@@ -2,7 +2,7 @@
 	import { getNoteCssClass } from '$lib/colours';
 	import { formatNoteDate } from '$lib/noteDate';
 	import { getNotePreview } from '$lib/notePreview';
-	import type { NoteOrdered, Friend } from '$lib/types';
+	import type { NoteOrdered, Friend, UserProfile } from '$lib/types';
 	import { GripVertical } from '@lucide/svelte';
 
 	import UserAvatar from './UserAvatar.svelte';
@@ -22,6 +22,9 @@
 	const clipThresholdPx = 4;
 	const avatarSize = 6;
 	const labelPreviewLimit = 80;
+	// Beyond three faces the stack eats the whole footer of a mobile column,
+	// so the rest collapse into a count.
+	const maxVisibleAvatars = 3;
 
 	let {
 		note,
@@ -47,6 +50,17 @@
 	const previewText = $derived(getNotePreview(note.textPlain, note.text));
 	const isEmpty = $derived(!note.title && !previewText);
 	const hasFooter = $derived(note.shared || editors.length > 0);
+
+	/*
+	 * The owner leads the stack on a note shared with you, so the face you see
+	 * first is whose note it is. Deduped because an owner who is also a
+	 * selected editor would otherwise repeat a key in the each block.
+	 */
+	const sharedWith = $derived<UserProfile[]>([
+		...new Map((note.shared ? [note.owner, ...editors] : editors).map((p) => [p.id, p])).values()
+	]);
+	const visibleAvatars = $derived(sharedWith.slice(0, maxVisibleAvatars));
+	const overflowCount = $derived(sharedWith.length - visibleAvatars.length);
 
 	/*
 	 * A role="button" element has presentational children, so none of the text
@@ -157,24 +171,32 @@
 	{/if}
 
 	{#if hasFooter}
-		<div class="mt-3 flex items-center gap-1.5">
-			{#if note.shared}
-				<UserAvatar
-					size={avatarSize}
-					picture={note.owner.picture || ''}
-					name={note.owner.name || ''}
-				/>
-			{/if}
-			{#each editors as editor (editor.id)}
-				<UserAvatar size={avatarSize} picture={editor.picture || ''} name={editor.name || ''} />
-			{/each}
+		<!--
+			Wrapping rather than shrinking: on a narrow column the chip drops to
+			its own line instead of squeezing the faces into ovals.
+		-->
+		<div class="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1.5">
+			<!-- Overlapped so a fourth person costs 18px, not a whole avatar. -->
+			<div class="flex shrink-0 items-center -space-x-2">
+				{#each visibleAvatars as person (person.id)}
+					<UserAvatar size={avatarSize} picture={person.picture || ''} name={person.name || ''} />
+				{/each}
+				{#if overflowCount > 0}
+					<span
+						class="text-label bg-ink/10 text-ink ring-paper flex size-6 shrink-0 items-center justify-center rounded-full pl-1 ring-2"
+						aria-hidden="true"
+					>
+						+{overflowCount}
+					</span>
+				{/if}
+			</div>
 			<!--
 				The chip tints whatever note colour is underneath rather than
 				using a fixed surface token, so it works on all six pastels.
 				text-ink, not text-ink-muted: muted on the tinted pastels falls
 				to 3.65:1 in dark mode.
 			-->
-			<span class="text-label bg-ink/10 text-ink rounded-chip ml-1 px-2 py-0.5 uppercase">
+			<span class="text-label bg-ink/10 text-ink rounded-chip shrink-0 px-2 py-0.5 uppercase">
 				Shared
 			</span>
 		</div>

--- a/src/components/UserAvatar.svelte
+++ b/src/components/UserAvatar.svelte
@@ -27,7 +27,7 @@
 			.join('');
 	}
 
-	const imageClass = $derived(`ring-paper m-0 rounded-full ring-2 ${sizeMap[size]}`);
+	const imageClass = $derived(`ring-paper m-0 rounded-full object-cover ring-2 ${sizeMap[size]}`);
 	const fallbackClass = $derived(
 		`bg-accent text-on-accent ring-paper m-0 flex items-center justify-center rounded-full text-xs font-medium ring-2 ${sizeMap[size]}`
 	);
@@ -44,7 +44,7 @@
 </script>
 
 {#snippet avatarImage(triggerProps?: Record<string, unknown>)}
-	<span {...triggerProps} class="inline-flex {sizeMap[size]}">
+	<span {...triggerProps} class="inline-flex shrink-0 {sizeMap[size]}">
 		{#if showFallback}
 			<span class={fallbackClass} aria-label={`Avatar of ${name}`} role="img">{initials}</span>
 		{:else}


### PR DESCRIPTION
Shared notes with more than a couple of collaborators squashed the avatars into ovals and left the `SHARED` chip fighting for the last few pixels of a mobile column.

## Cause

Two things:

1. `UserAvatar`'s wrapper was a flex item with no `shrink-0`, so the browser compressed the fixed-size circles rather than overflowing.
2. The footer laid every face out in a spaced row, which has no answer for a fourth or fifth person in a ~130px column.

## Change

**`Note.svelte`**
- Avatars render as an **overlapped stack** (`-space-x-2`), capped at three faces; the rest collapse into a `+N` circle tinted with the same `bg-ink/10` as the Shared chip.
- Footer is `flex-wrap` with `gap-y-1.5`, so on a narrow column the chip drops to its own line instead of squeezing the stack. Desktop columns keep it inline.
- Owner and editors merged into one `sharedWith` list (owner first, so the leading face is whose note it is), deduped by id — the single keyed `{#each}` would otherwise repeat a key if the owner were also a selected editor.

**`UserAvatar.svelte`**
- `shrink-0` on the wrapper — the root cause, fixed for every usage.
- `object-cover` on the image so non-square profile pictures crop instead of stretch.

## Verification

Checked in the running app at 360px and 1440px, light and dark, with 1–6 people per card: nothing compresses, the chip wraps only when width demands it, and `ring-paper` keeps the faces separated in both themes.

`pnpm check` passes with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHLGgHgYvVPLDKMGVTHfnL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved shared-note avatar displays by combining and deduplicating participants.
  * Limited visible avatars to three and added a badge showing additional participants.
  * Updated the footer layout to better accommodate avatar groups.

* **Style**
  * Improved avatar presentation with consistent outlines and sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->