### PR TITLE
fix: keep owner profile in dedupe and voice the collaborator count

### DIFF
--- a/src/components/Note.svelte
+++ b/src/components/Note.svelte
@@ -54,13 +54,24 @@
 	/*
 	 * The owner leads the stack on a note shared with you, so the face you see
 	 * first is whose note it is. Deduped because an owner who is also a
-	 * selected editor would otherwise repeat a key in the each block.
+	 * selected editor would otherwise repeat a key in the each block — first
+	 * occurrence wins so the owner's own profile stays authoritative over the
+	 * possibly staler snapshot in the friend list.
 	 */
-	const sharedWith = $derived<UserProfile[]>([
-		...new Map((note.shared ? [note.owner, ...editors] : editors).map((p) => [p.id, p])).values()
-	]);
+	const sharedWith = $derived<UserProfile[]>(
+		(note.shared ? [note.owner, ...editors] : editors).filter(
+			(person, index, all) => all.findIndex((other) => other.id === person.id) === index
+		)
+	);
 	const visibleAvatars = $derived(sharedWith.slice(0, maxVisibleAvatars));
 	const overflowCount = $derived(sharedWith.length - visibleAvatars.length);
+	// The +N badge is decorative, so the count only reaches assistive tech
+	// through the card's own label.
+	const sharedLabel = $derived(
+		sharedWith.length > 0
+			? `Shared with ${sharedWith.length} ${sharedWith.length === 1 ? 'person' : 'people'}`
+			: ''
+	);
 
 	/*
 	 * A role="button" element has presentational children, so none of the text
@@ -72,7 +83,7 @@
 			`Edit note ${index + 1}`,
 			note.title || previewText.slice(0, labelPreviewLimit) || 'Empty note',
 			dateLabel,
-			hasFooter ? 'Shared' : ''
+			sharedLabel
 		]
 			.filter(Boolean)
 			.join(', ')


### PR DESCRIPTION
Follow-up to #839. These two fixes were pushed a minute after that PR was merged, so they never landed — the branch had already been deleted and the push re-created it against a closed PR. Same commit, rebased onto current `main`.

Both points came from CodeRabbit's review on #839:

- **First-occurrence-wins dedupe.** The `new Map()` version let a matching `editors` entry overwrite the owner's value, so an owner who is also a selected editor could render the friend-list's staler name and picture. Ordering is unchanged.
- **Collaborator count in the accessible label.** The `+N` badge is `aria-hidden`, so the card now announces `"Shared with 3 people"` rather than a bare `"Shared"` — screen-reader users could not otherwise tell that more collaborators exist.

`pnpm check` passes with 0 errors. No test asserted the old label string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHLGgHgYvVPLDKMGVTHfnL