### PR TITLE
fix: silence the note-updated toast and move toasts to top centre

### DIFF
--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -334,7 +334,7 @@ form resolves to `transition-duration: var(--duration-fast)`. The square-bracket
 | Button press | 100ms press | Scale to .94 then settle. Pairs with the existing 50ms haptic.                                          |
 | FAB          | 360ms press | Icon rotates 90° from plus to close as the sheet opens.                                                 |
 | Reorder      | 240ms move  | FLIP on surviving cards so neighbours slide rather than jump.                                           |
-| Toast        | 240ms enter | Rises 12px and fades in above the nav pill.                                                             |
+| Toast        | 240ms enter | Drops 12px and fades in at top centre, clearing the sticky header.                                      |
 | Save         | 160ms move  | Label crossfades to a check, holds 800ms, returns. No spinner for sub-second work.                      |
 
 **All of it sits behind `prefers-reduced-motion`,** which the app does not honour anywhere

--- a/src/components/Toaster.svelte
+++ b/src/components/Toaster.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
 	import { Toaster as SonnerToaster } from 'svelte-sonner';
+
+	// Clears the sticky 5rem header, plus a 1rem gap, so a top-centre toast
+	// never covers the search.
+	const toastOffsetValue = { top: '6rem' };
 </script>
 
-<SonnerToaster position="bottom-center" richColors mobileOffset={{ bottom: '5rem' }} />
+<SonnerToaster
+	position="top-center"
+	richColors
+	offset={toastOffsetValue}
+	mobileOffset={toastOffsetValue}
+/>

--- a/src/routes/my/board/+page.svelte
+++ b/src/routes/my/board/+page.svelte
@@ -70,7 +70,6 @@
 				}),
 			revert: ([, original]) => boardState.updateNote(original),
 			errorMessage: 'Failed to update note. Try again.',
-			successMessage: 'Note updated',
 			toastMessages
 		});
 	}

--- a/tests/noteManagement.test.ts
+++ b/tests/noteManagement.test.ts
@@ -34,12 +34,19 @@ test('basic note management', async ({ page }) => {
 	const editor = page.getByRole('textbox').nth(2);
 	await editor.fill(noteContent);
 
-	await page.getByRole('button', { name: 'Save note' }).click();
+	// Updates are silent — no success toast — so wait on the request itself.
+	// Match on the title so an in-flight PATCH from the earlier colour change
+	// can't satisfy this wait.
+	const updateNotePromise = page.waitForResponse(
+		(response) =>
+			response.url().includes('/api/notes') &&
+			response.request().method() === 'PATCH' &&
+			response.request().postDataJSON()?.title === noteTitle &&
+			response.status() < 400
+	);
 
-	// Verify the success toast appears once the note is updated on the server.
-	// The colour change earlier in this test may have left its own "Note
-	// updated" toast still on screen, so target the most recent one.
-	await expect(page.getByText('Note updated').last()).toBeVisible();
+	await page.getByRole('button', { name: 'Save note' }).click();
+	await updateNotePromise;
 
 	// Wait for the note to be saved - verify the note appears on the board
 	await expect(page.getByText(noteTitle)).toBeVisible();


### PR DESCRIPTION
## What

- Success toasts now fire only for **create** and **delete**. Saving an edit is silent — `successMessage: 'Note updated'` is gone from `handleUpdate`. The error toast on a failed update is untouched.
- Toasts move from bottom-centre to **top-centre**, with a `6rem` top offset (desktop and mobile) so they clear the sticky `5rem` header with a 1rem gap.

## Why 6rem and not less

At `5.5rem` the clearance below the 80px header was 8px, and sonner's enter animation slid the toast up behind the header. `6rem` gives a 1rem gap and the toast drops out from under the header cleanly.

## Verified in the browser

Logged in as the test user against a dev server:

- Create → "Note created" toast, top centre.
- Save an edit → two `PATCH /api/notes/...` both `200`, zero `[data-sonner-toast]` nodes in the DOM.
- Delete → "Note deleted" toast, top centre.
- Settled geometry: toast `top: 96px` vs header bottom `80px`, centred (x = 720 in a 1440 viewport). Same `top: 96px` on iPhone 14 with 16px side margins.

## Test change

`tests/noteManagement.test.ts` used the "Note updated" toast as its sync point for the save. It now waits on the PATCH whose post body carries the new title — matching on title so an in-flight PATCH from the earlier colour change can't satisfy the wait.

## Known, not addressed here

1. `Toaster.svelte` passes no `theme` to sonner, so the toast renders light in dark mode. Pre-existing; more visible now that it sits at the top.
2. On mobile the toast overlays the Title field for its 4s life after creating a note. Doesn't steal focus, but a tap there hits the toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHLGgHgYvVPLDKMGVTHfnL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toast notifications now appear at the top center of the screen, below the sticky header, on desktop and mobile.
  * Toast positioning and animation guidance has been updated in the design documentation.

* **Bug Fixes**
  * Note updates now use the appropriate toast messaging behavior and provide clearer failure feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->