### PR TITLE
chore: pin both deploy jobs to the Node version from package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,9 +91,13 @@ jobs:
       url: https://${{ env.PREVIEW_DOMAIN }}
     steps:
       - uses: actions/checkout@v7
+      - name: Setup pnpm and Node
+        uses: pnpm/setup@v1
+        with:
+          install: false
       - name: Deploy
         run: |
-          npm install --global vercel@canary
+          pnpm add --global vercel@canary
           vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
           vercel build --token=${{ secrets.VERCEL_TOKEN }}
           url="$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - name: Setup pnpm and Node
+        uses: pnpm/setup@v1
         with:
-          node-version: 24
+          install: false
       - name: Deploy
         run: |
-          npm install --global vercel@canary
+          pnpm add --global vercel@canary
           vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
           vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Follow-up to #842, closing the Node version drift in the deploy jobs.

## The drift

- `main.yml` pinned Node with a floating `node-version: 24` via `actions/setup-node`.
- `ci.yml`’s `deploy_preview` had **no** Node setup at all and used whatever the runner shipped.

Both run `vercel build`, so a release could be compiled on a different Node than the one `pnpm check` / tests ran against.

## Fix

Both jobs now use `pnpm/setup@v1`, which reads `devEngines.runtime` from `package.json` and resolves the same **24.16.0** as the rest of CI. The version is declared in exactly one place — no workflow restates it.

`vercel` is installed with `pnpm add --global` instead of `npm install --global`: pnpm links only `node` from the runtime onto `PATH`, and the action exports `PNPM_HOME` with `$PNPM_HOME/bin` on `PATH`, so the global bin resolves without depending on the runner image separately providing `npm`.

`install: false` is set on both — neither deploy job needs `node_modules`, since `vercel build` runs its own install.

`engines.node` stays `"24.x"`: that is the consumer-facing range, while `devEngines.runtime` is the exact dev/CI pin. Only the latter can pin a single version, so it is the source of truth here.

## Verification

The production deploy in `main.yml` only runs on push to `main`, so PR CI cannot exercise it directly. `deploy_preview` now uses the **identical** `pnpm/setup` + `pnpm add --global` pattern, so a green **Deploy Preview** on this PR validates the exact mechanism before it reaches production. This PR should not merge if that job fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHLGgHgYvVPLDKMGVTHfnL