### PR TITLE
fix: derive Auth0 redirect_uri from the request origin on preview deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
   PUBLIC_BUILD: ${{ github.ref_name }}-${{ github.run_number }}
   PRISMA_FIELD_ENCRYPTION_KEY: ${{ secrets.PRISMA_FIELD_ENCRYPTION_KEY }}
-  PREVIEW_DOMAIN: notes-dev.vasic.com.au
   PUBLIC_BASE_URL: ${{ vars.PUBLIC_BASE_URL }}
   SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
   SES_AWS_ACCESS_KEY_ID: ${{ secrets.SES_AWS_ACCESS_KEY_ID }}
@@ -102,7 +101,7 @@ jobs:
           vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
           vercel build --token=${{ secrets.VERCEL_TOKEN }}
           url="$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})"
-          # Auth0 allows the whole *-dejan-vasics-projects.vercel.app range, so login works
-          # on this per-deploy URL. The alias is only a stable "latest preview" convenience.
-          vercel alias --token=${{ secrets.VERCEL_TOKEN }} set "$url" ${{ env.PREVIEW_DOMAIN }}
+          # VERCEL_TOKEN doesn't have access to alias custom domains, so notes-dev.vasic.com.au
+          # can't be repointed here. Not needed anyway — Auth0 allows the whole
+          # *-dejan-vasics-projects.vercel.app range, so login works on this per-deploy URL.
           echo "deployment_url=$url" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,10 @@ jobs:
     name: Deploy Preview
     runs-on: ubuntu-latest
     needs: [build, test]
-    concurrency: preview_deploy
+    concurrency: preview_deploy-${{ github.ref }}
     environment:
       name: preview
-      url: https://${{ env.PREVIEW_DOMAIN }}
+      url: ${{ steps.deploy.outputs.deployment_url }}
     steps:
       - uses: actions/checkout@v7
       - name: Setup pnpm and Node
@@ -96,10 +96,13 @@ jobs:
         with:
           install: false
       - name: Deploy
+        id: deploy
         run: |
           pnpm add --global vercel@canary
           vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
           vercel build --token=${{ secrets.VERCEL_TOKEN }}
           url="$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})"
-          # vercel alias --token=${{ secrets.VERCEL_TOKEN }} set "$url" ${{ env.PREVIEW_DOMAIN }}
-          echo "deployment_url=$url" >> $GITHUB_ENV
+          # Auth0 allows the whole *-dejan-vasics-projects.vercel.app range, so login works
+          # on this per-deploy URL. The alias is only a stable "latest preview" convenience.
+          vercel alias --token=${{ secrets.VERCEL_TOKEN }} set "$url" ${{ env.PREVIEW_DOMAIN }}
+          echo "deployment_url=$url" >> $GITHUB_OUTPUT

--- a/src/lib/auth/baseUrl.test.ts
+++ b/src/lib/auth/baseUrl.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { getAuthBaseUrl } from './baseUrl';
+
+vi.mock('$env/static/public', () => ({
+	PUBLIC_BASE_URL: 'https://notes-dev.vasic.com.au'
+}));
+
+describe('getAuthBaseUrl', () => {
+	test.each([
+		['https://notes-i4q7stq7j-dejan-vasics-projects.vercel.app', true],
+		['https://notes.vasic.com.au', true],
+		['https://notes-dev.vasic.com.au', true],
+		['http://localhost:3377', true],
+		['http://localhost', true],
+		['https://notes-dejan-vasics-projects.vercel.app.evil.com', false],
+		['https://evil.com', false],
+		['https://notes.vasic.com.au.evil.com', false],
+		['http://notes.vasic.com.au', false]
+	])('%s is used as-is: %s', (origin, isAllowed) => {
+		const result = getAuthBaseUrl(new URL(`${origin}/api/auth/login`));
+
+		expect(result).toBe(isAllowed ? origin : 'https://notes-dev.vasic.com.au');
+	});
+});

--- a/src/lib/auth/baseUrl.ts
+++ b/src/lib/auth/baseUrl.ts
@@ -1,0 +1,23 @@
+import { PUBLIC_BASE_URL } from '$env/static/public';
+
+// Vercel assigns every preview deploy a throwaway host under the team slug, so the
+// origin is only known at request time — PUBLIC_BASE_URL is baked in at build time.
+const previewOriginPattern = /^https:\/\/[a-z0-9-]+-dejan-vasics-projects\.vercel\.app$/;
+const localhostOriginPattern = /^http:\/\/localhost(:\d+)?$/;
+const namedOrigins: Readonly<string[]> = [
+	'https://notes.vasic.com.au',
+	'https://notes-dev.vasic.com.au'
+];
+
+const isAllowedOrigin = (origin: string): boolean =>
+	origin === PUBLIC_BASE_URL ||
+	namedOrigins.includes(origin) ||
+	previewOriginPattern.test(origin) ||
+	localhostOriginPattern.test(origin);
+
+/**
+ * Resolves the origin Auth0 should redirect back to. Falls back to PUBLIC_BASE_URL for
+ * anything unrecognised, so a forged Host header can never reach Auth0 as a redirect_uri.
+ */
+export const getAuthBaseUrl = (url: URL): string =>
+	isAllowedOrigin(url.origin) ? url.origin : PUBLIC_BASE_URL;

--- a/src/lib/auth/getToken.ts
+++ b/src/lib/auth/getToken.ts
@@ -7,7 +7,7 @@ import { tryFetchJson } from '$lib/server/serverFetch';
 
 interface GetTokenParams {
 	code: string;
-	baseUrl: string;
+	redirectUri: string;
 }
 
 export const GetTokenResponseSchema = z.object({
@@ -22,7 +22,7 @@ export type GetTokenResponse = z.infer<typeof GetTokenResponseSchema>;
 
 export const getToken = ({
 	code,
-	baseUrl
+	redirectUri
 }: GetTokenParams): ResultAsync<GetTokenResponse, ServerError> => {
 	return tryFetchJson(`https://${AUTH0_DOMAIN}/oauth/token`, {
 		method: 'POST',
@@ -30,7 +30,7 @@ export const getToken = ({
 			code,
 			client_id: AUTH0_CLIENT_ID,
 			client_secret: AUTH0_CLIENT_SECRET,
-			redirect_uri: `${baseUrl}/api/auth/callback`,
+			redirect_uri: redirectUri,
 			grant_type: 'authorization_code'
 		}),
 		headers: {

--- a/src/lib/auth/getToken.ts
+++ b/src/lib/auth/getToken.ts
@@ -2,12 +2,12 @@ import { ResultAsync } from 'neverthrow';
 import { z } from 'zod';
 
 import { AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_DOMAIN } from '$env/static/private';
-import { PUBLIC_BASE_URL } from '$env/static/public';
 import type { ServerError } from '$lib/types';
 import { tryFetchJson } from '$lib/server/serverFetch';
 
 interface GetTokenParams {
 	code: string;
+	baseUrl: string;
 }
 
 export const GetTokenResponseSchema = z.object({
@@ -20,14 +20,17 @@ export const GetTokenResponseSchema = z.object({
 
 export type GetTokenResponse = z.infer<typeof GetTokenResponseSchema>;
 
-export const getToken = ({ code }: GetTokenParams): ResultAsync<GetTokenResponse, ServerError> => {
+export const getToken = ({
+	code,
+	baseUrl
+}: GetTokenParams): ResultAsync<GetTokenResponse, ServerError> => {
 	return tryFetchJson(`https://${AUTH0_DOMAIN}/oauth/token`, {
 		method: 'POST',
 		body: JSON.stringify({
 			code,
 			client_id: AUTH0_CLIENT_ID,
 			client_secret: AUTH0_CLIENT_SECRET,
-			redirect_uri: `${PUBLIC_BASE_URL}/api/auth/callback`,
+			redirect_uri: `${baseUrl}/api/auth/callback`,
 			grant_type: 'authorization_code'
 		}),
 		headers: {

--- a/src/routes/api/auth/callback/+server.ts
+++ b/src/routes/api/auth/callback/+server.ts
@@ -1,6 +1,7 @@
 import { ResultAsync } from 'neverthrow';
 import type { RequestHandler } from '@sveltejs/kit';
 
+import { getAuthBaseUrl } from '$lib/auth/baseUrl';
 import { getToken } from '$lib/auth/getToken';
 import type { AuthUserProfile } from '$lib/types';
 import { getOrCreateUser } from '$lib/server/services/userService';
@@ -19,7 +20,7 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 		return new Response('Invalid state', { status: 403 });
 	}
 
-	const result = await getToken({ code })
+	const result = await getToken({ code, baseUrl: getAuthBaseUrl(url) })
 		.andThen((token) => tryVerifyToken<AuthUserProfile>(token.id_token))
 		.andThen((authUser) => getOrCreateUser({ email: authUser.email, authUserProfile: authUser }))
 		.andThen((user) =>

--- a/src/routes/api/auth/callback/+server.ts
+++ b/src/routes/api/auth/callback/+server.ts
@@ -20,7 +20,11 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 		return new Response('Invalid state', { status: 403 });
 	}
 
-	const result = await getToken({ code, baseUrl: getAuthBaseUrl(url) })
+	// Must match the redirect_uri sent to /authorize (including the returnUrl query)
+	// exactly, or Auth0 rejects the code exchange.
+	const redirectUri = `${getAuthBaseUrl(url)}/api/auth/callback?returnUrl=${encodeURIComponent(returnUrl)}`;
+
+	const result = await getToken({ code, redirectUri })
 		.andThen((token) => tryVerifyToken<AuthUserProfile>(token.id_token))
 		.andThen((authUser) => getOrCreateUser({ email: authUser.email, authUserProfile: authUser }))
 		.andThen((user) =>

--- a/src/routes/api/auth/login/+server.ts
+++ b/src/routes/api/auth/login/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { AUTH0_DOMAIN, AUTH0_CLIENT_ID } from '$env/static/private';
-import { PUBLIC_BASE_URL } from '$env/static/public';
+import { getAuthBaseUrl } from '$lib/auth/baseUrl';
 
 export const GET: RequestHandler = ({ cookies, url }) => {
 	const csrfState = Math.random().toString(36).substring(7);
@@ -18,7 +18,7 @@ export const GET: RequestHandler = ({ cookies, url }) => {
 		scope: 'openid profile email',
 		response_type: 'code',
 		client_id: AUTH0_CLIENT_ID,
-		redirect_uri: `${PUBLIC_BASE_URL}/api/auth/callback?returnUrl=${returnUrl}`,
+		redirect_uri: `${getAuthBaseUrl(url)}/api/auth/callback?returnUrl=${returnUrl}`,
 		state: csrfState,
 		...(screenHint ? { screen_hint: 'signup' } : null)
 	};

--- a/src/routes/api/auth/logout/+server.ts
+++ b/src/routes/api/auth/logout/+server.ts
@@ -1,12 +1,12 @@
 import type { RequestHandler } from '@sveltejs/kit';
 
 import { clearAuthCookie } from '$lib/auth/session';
+import { getAuthBaseUrl } from '$lib/auth/baseUrl';
 import { AUTH0_DOMAIN, AUTH0_CLIENT_ID } from '$env/static/private';
 
-export const GET: RequestHandler = ({ cookies, request }) => {
+export const GET: RequestHandler = ({ cookies, url }) => {
 	clearAuthCookie(cookies);
-	const url = new URL(request.url);
-	const returnTo = encodeURIComponent(url.origin);
+	const returnTo = encodeURIComponent(getAuthBaseUrl(url));
 	const location = `https://${AUTH0_DOMAIN}/v2/logout?client_id=${AUTH0_CLIENT_ID}&returnTo=${returnTo}`;
 
 	return new Response('Logout', {


### PR DESCRIPTION
## Summary
- Preview branch deploys couldn't authenticate: `PUBLIC_BASE_URL` is baked in at `vercel build` time, before the per-branch deployment URL exists, so login always redirected through the stale `notes-dev.vasic.com.au` alias instead of the branch's own host.
- Adds `getAuthBaseUrl()` (`src/lib/auth/baseUrl.ts`) to resolve the Auth0 `redirect_uri`/`returnTo` from the request's origin against an allowlist (prod, notes-dev, `*-dejan-vasics-projects.vercel.app` preview hosts, localhost), falling back to `PUBLIC_BASE_URL` for anything unrecognised.
- Threads that through `login`, `callback`, and `logout` routes, and `getToken`.
- CI `deploy_preview` now reports the actual deployment URL as the job's `environment.url` (was hardcoded to `PREVIEW_DOMAIN`, which the deploy step could never satisfy since it writes to `$GITHUB_ENV`, not `$GITHUB_OUTPUT`) and scopes deploy concurrency per branch instead of globally.

Fixes #816 

## Requires (not part of this PR)
A matching Auth0 dashboard change on application `dx1gTpC49cZYd0wUixD4ZvZjT34LhZt9`:
- Allowed Callback URLs: `https://*-dejan-vasics-projects.vercel.app/api/auth/callback`
- Allowed Logout URLs: `https://*-dejan-vasics-projects.vercel.app`

Without it, this code change is inert — Auth0 will still reject the preview redirect_uri.

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm lint`
- [x] `pnpm build:tsc`
- [x] `pnpm vitest run` — 95/95 passing, including new `src/lib/auth/baseUrl.test.ts`
- [ ] After the Auth0 dashboard change is made: open this PR's preview deployment URL, log in, confirm redirect lands back on that same host, confirm logout does too
- [ ] Re-verify login/logout on `notes.vasic.com.au` after merge (shared Auth0 app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHLGgHgYvVPLDKMGVTHfnL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication now supports secure sign-in, callback, and sign-out redirects across approved local, production, and preview environments.
  * Preview deployments now display their actual deployment URL automatically.
* **Bug Fixes**
  * Prevented unrecognized or manipulated origins from being used for authentication redirects.
  * Improved preview deployment isolation so concurrent previews retain the correct environment URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->