### PR TITLE
test: cover the authenticated board offline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,9 @@ jobs:
 
   test_offline:
     env:
-      PUBLIC_BASE_URL: http://localhost:4173
+      TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
+      TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+      PUBLIC_BASE_URL: http://localhost:3377
       HOME: /root
     name: Test offline mode
     timeout-minutes: 30
@@ -103,7 +105,9 @@ jobs:
         run: pnpm install --frozen-lockfile
       # The service worker precaches nothing in dev, so this suite builds and
       # serves the production output itself — see playwright.offline.config.ts.
-      # No login is involved, so it needs no test user or database migration.
+      # It runs on 3377 like the suite above, because Auth0 only accepts a
+      # callback on that origin and one test signs in to reach the board. The
+      # two jobs are on separate runners, so sharing the port costs nothing.
       - name: Run offline Playwright tests
         run: pnpm exec playwright test --config playwright.offline.config.ts --reporter=list
       - name: Upload offline test results

--- a/playwright.offline.config.ts
+++ b/playwright.offline.config.ts
@@ -6,15 +6,23 @@ import type { PlaywrightTestConfig } from '@playwright/test';
  * precaches nothing and an offline reload would fail on vite's module
  * requests rather than on anything the service worker controls.
  *
- * Kept separate from playwright.config.ts so the everyday suite keeps running
- * against `pnpm dev` on the Auth0-whitelisted port 3377 and stays fast.
+ * Kept separate from playwright.config.ts because that one runs against
+ * `pnpm dev` and this needs `vite preview`. Both use port 3377, since Auth0's
+ * Allowed Callback URLs only cover that origin — anything else cannot log in,
+ * which would put the authenticated board out of reach here. In CI the two
+ * suites are separate jobs on separate runners, so they never contend; locally
+ * only one can hold the port at a time, and --strictPort makes that a loud
+ * failure rather than a silent bump onto a port Auth0 will reject.
  */
-const previewPort = 4173;
+const previewPort = 3377;
 const buildTimeoutMs = 240_000;
 
 const config: PlaywrightTestConfig = {
 	webServer: {
 		command: `pnpm build && pnpm preview --port ${previewPort} --strictPort`,
+		// Never adopt a stray server: a leftover `pnpm dev` on this port serves an
+		// unbuilt app whose service worker precaches nothing, and every test here
+		// would fail for a reason that has nothing to do with the code.
 		reuseExistingServer: false,
 		port: previewPort,
 		timeout: buildTimeoutMs,

--- a/tests-offline/offline.test.ts
+++ b/tests-offline/offline.test.ts
@@ -3,6 +3,41 @@ import { expect, test, type Page } from '@playwright/test';
 const assetCachePrefix = 'assets-';
 const pageCachePrefix = 'pages-';
 const offlineHeading = "You're offline";
+const boardPath = '/my/board';
+const loginTimeoutMs = 15_000;
+// localCache.ts keys board snapshots as `board:<userId>`.
+const boardKeyMatcher = expect.stringMatching(/^board:/);
+
+/*
+ * idb-keyval's default database and store names. Hardcoded rather than imported
+ * because this runs in the page, outside the app bundle — if the library ever
+ * renames them this fails loudly, which is the point.
+ */
+const idbName = 'keyval-store';
+const idbStore = 'keyval';
+
+function readSnapshotKeys(page: Page): Promise<string[]> {
+	return page.evaluate(
+		({ idbName, idbStore }) =>
+			new Promise<string[]>((resolve) => {
+				const open = indexedDB.open(idbName);
+				open.onerror = () => resolve([]);
+				open.onsuccess = () => {
+					if (!open.result.objectStoreNames.contains(idbStore)) {
+						resolve([]);
+						return;
+					}
+					const request = open.result
+						.transaction(idbStore, 'readonly')
+						.objectStore(idbStore)
+						.getAllKeys();
+					request.onerror = () => resolve([]);
+					request.onsuccess = () => resolve(request.result.map(String));
+				};
+			}),
+		{ idbName, idbStore }
+	);
+}
 
 // The first navigation to an origin is not intercepted, because the service
 // worker only starts controlling the page once it has activated. Reloading
@@ -86,8 +121,7 @@ test('never serves API responses from the cache', async ({ page, context }) => {
 
 // Cached documents hold SSR-rendered user data, so logging out has to drop them.
 // The service worker keys this off the request path rather than the session, so
-// it is reachable without logging in — which this suite cannot do, because Auth0
-// only whitelists the dev port.
+// this needs no session of its own.
 test('purges cached pages on logout', async ({ page }) => {
 	await openControlledPage(page, '/');
 	expect(findCache(await readCacheKeys(page), pageCachePrefix)).toContain('/');
@@ -106,3 +140,48 @@ test('purges cached pages on logout', async ({ page }) => {
 		.poll(async () => findCache(await readCacheKeys(page), pageCachePrefix))
 		.not.toContain('/');
 });
+
+/*
+ * The whole point of #788: the board is what people actually open offline, and
+ * it is the one path the unauthenticated tests above cannot reach.
+ *
+ * Board state hydrates from IndexedDB (localCache.ts) rather than from the
+ * document, so this waits for that snapshot to be written before cutting the
+ * network — otherwise the page would render from cache with an empty board and
+ * the assertion would pass for the wrong reason.
+ */
+test('renders the authenticated board while offline', async ({ page, context }) => {
+	await page.goto('/');
+	await page.getByRole('link', { name: 'Login' }).click();
+	await login(page);
+
+	await page.evaluate(async () => {
+		await navigator.serviceWorker.ready;
+	});
+	await page.reload();
+	await page.waitForFunction(() => navigator.serviceWorker.controller !== null);
+
+	const createButton = page.getByRole('button', { name: 'Create a new note' });
+	await expect(createButton).toBeVisible();
+
+	expect(findCache(await readCacheKeys(page), pageCachePrefix)).toContain(boardPath);
+	await expect
+		.poll(() => readSnapshotKeys(page))
+		.toEqual(expect.arrayContaining([boardKeyMatcher]));
+
+	const notesBefore = await page.getByRole('button', { name: /^Edit note/ }).count();
+
+	await context.setOffline(true);
+	await page.reload();
+
+	await expect(page.getByRole('heading', { name: offlineHeading })).toBeHidden();
+	await expect(createButton).toBeVisible();
+	expect(await page.getByRole('button', { name: /^Edit note/ }).count()).toBe(notesBefore);
+});
+
+async function login(page: Page) {
+	await page.getByRole('textbox', { name: 'Email address' }).fill(process.env.TEST_USER_EMAIL!);
+	await page.getByRole('textbox', { name: 'Password' }).fill(process.env.TEST_USER_PASSWORD!);
+	await page.getByRole('button', { name: 'Continue', exact: true }).click();
+	await page.waitForURL(/\/my\/board/, { timeout: loginTimeoutMs });
+}

--- a/tests-offline/offline.test.ts
+++ b/tests-offline/offline.test.ts
@@ -169,14 +169,27 @@ test('renders the authenticated board while offline', async ({ page, context }) 
 		.poll(() => readSnapshotKeys(page))
 		.toEqual(expect.arrayContaining([boardKeyMatcher]));
 
-	const notesBefore = await page.getByRole('button', { name: /^Edit note/ }).count();
+	const notes = page.getByRole('button', { name: /^Edit note/ });
+	const notesBefore = await notes.count();
+
+	/*
+	 * Without this the comparison below is vacuous: an offline reload that
+	 * hydrated nothing would render zero notes and still match a zero baseline.
+	 * The account this suite signs in as is expected to hold at least one note.
+	 */
+	expect(notesBefore).toBeGreaterThan(0);
+	const firstNoteLabel = await notes.first().getAttribute('aria-label');
 
 	await context.setOffline(true);
 	await page.reload();
 
 	await expect(page.getByRole('heading', { name: offlineHeading })).toBeHidden();
 	await expect(createButton).toBeVisible();
-	expect(await page.getByRole('button', { name: /^Edit note/ }).count()).toBe(notesBefore);
+	expect(await notes.count()).toBe(notesBefore);
+
+	// The cached document renders an empty board — the notes themselves only
+	// exist in IndexedDB — so matching content proves hydration actually ran.
+	expect(await notes.first().getAttribute('aria-label')).toBe(firstNoteLabel);
 });
 
 async function login(page: Page) {


### PR DESCRIPTION
Closes the one gap in #788 that CI did not reach.

## Why it was missing

The offline suite ran on port 4173 — vite preview's default, which I picked without thinking about what it cost. Auth0's Allowed Callback URLs only cover the `3377` origin, so on 4173 the login redirect is rejected and the suite could not sign in. The authenticated board, which is the whole point of #788, was therefore verified by hand only.

Nothing in the app enforced this: `getAuthBaseUrl` accepts any localhost port (`src/lib/auth/baseUrl.ts:6`). It was purely the port choice.

## The change

Moving the offline preview to 3377 makes login work.

- **CI**: costs nothing. `test` and `test_offline` are separate jobs on separate runners, so both can own the port.
- **Locally**: only one suite can hold 3377 at a time. `--strictPort` makes that a loud failure instead of a silent bump onto a port Auth0 would reject.
- `reuseExistingServer` stays `false`, so a leftover `pnpm dev` is never adopted in place of a production build — that would serve an unbuilt app whose service worker precaches nothing, and every test would fail for an unrelated reason.

## The test

Signs in, confirms the board document is cached *and* its IndexedDB snapshot written, then cuts the network and reloads.

Waiting on the snapshot is the part that matters. Board state hydrates from IndexedDB (`localCache.ts`), not from the document — so without that wait the page could render from cache with an empty board and the assertion would pass for the wrong reason.

## Verification

All 6 offline tests pass. **Verified discriminating**: bypassing `/my/board` in the service worker so it is never cached fails this test and no other — the five existing tests are unaffected, which is what you want from an isolated mutation.

Existing suites unchanged: 3 Playwright, 95 unit.

## Note for the reviewer

The login helper is duplicated from `tests/noteManagement.test.ts` rather than shared. Four lines, and the two suites have no common directory — but it is the kind of thing that drifts, so worth a shared helper if a third caller ever appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHLGgHgYvVPLDKMGVTHfnL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when opening previously cached boards while offline.
  - Preserved board content and note counts during offline use after authentication.

- **Tests**
  - Added coverage for authenticated offline access, cached board data, and session-independent data cleanup.
  - Improved end-to-end validation of login and offline board workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->