### PR TITLE
Add offline status indicator to the header

### DIFF
--- a/src/components/OfflineIndicator.svelte
+++ b/src/components/OfflineIndicator.svelte
@@ -19,7 +19,8 @@
 -->
 <div role="status">
 	{#if connectivityState.isOffline}
-		<span aria-label={offlineLabel} transition:fade={{ duration: reduceMotion(durationFastMs) }}>
+		<span class="sr-only">{offlineLabel}</span>
+		<span transition:fade={{ duration: reduceMotion(durationFastMs) }}>
 			<WifiOff size={iconSize} aria-hidden="true" class="text-warning" />
 		</span>
 	{/if}

--- a/src/components/OfflineIndicator.svelte
+++ b/src/components/OfflineIndicator.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { fade } from 'svelte/transition';
+	import { WifiOff } from '@lucide/svelte';
+
+	import { getConnectivityState } from '$lib/state/connectivityState.svelte';
+	import { durationFastMs, reduceMotion } from '$lib/motion';
+
+	const iconSize = 20;
+	const offlineLabel = "You're offline. Changes will sync once you're back online.";
+
+	const connectivityState = getConnectivityState();
+</script>
+
+<!--
+	The role="status" region stays mounted whether online or offline so a
+	screen reader has already registered it before the content inside changes
+	- toggling the whole element in and out of the DOM does not reliably
+	announce the update.
+-->
+<div role="status">
+	{#if connectivityState.isOffline}
+		<span aria-label={offlineLabel} transition:fade={{ duration: reduceMotion(durationFastMs) }}>
+			<WifiOff size={iconSize} aria-hidden="true" class="text-warning" />
+		</span>
+	{/if}
+</div>

--- a/src/lib/state/connectivityState.svelte.ts
+++ b/src/lib/state/connectivityState.svelte.ts
@@ -1,8 +1,10 @@
-import { getContext, setContext } from 'svelte';
+import { getContext, onDestroy, setContext } from 'svelte';
 import { browser } from '$app/environment';
 
 export class ConnectivityState {
 	#online = $state(true);
+	#onOnline = () => (this.#online = true);
+	#onOffline = () => (this.#online = false);
 
 	constructor() {
 		if (!browser) {
@@ -10,19 +12,31 @@ export class ConnectivityState {
 		}
 
 		this.#online = navigator.onLine;
-		window.addEventListener('online', () => (this.#online = true));
-		window.addEventListener('offline', () => (this.#online = false));
+		window.addEventListener('online', this.#onOnline);
+		window.addEventListener('offline', this.#onOffline);
 	}
 
 	get isOffline() {
 		return !this.#online;
+	}
+
+	destroy() {
+		if (!browser) {
+			return;
+		}
+
+		window.removeEventListener('online', this.#onOnline);
+		window.removeEventListener('offline', this.#onOffline);
 	}
 }
 
 const ConnectivityStateKey = Symbol('ConnectivityState');
 
 export function setConnectivityState() {
-	return setContext(ConnectivityStateKey, new ConnectivityState());
+	const connectivityState = new ConnectivityState();
+	setContext(ConnectivityStateKey, connectivityState);
+	onDestroy(() => connectivityState.destroy());
+	return connectivityState;
 }
 
 export function getConnectivityState() {

--- a/src/lib/state/connectivityState.svelte.ts
+++ b/src/lib/state/connectivityState.svelte.ts
@@ -1,0 +1,30 @@
+import { getContext, setContext } from 'svelte';
+import { browser } from '$app/environment';
+
+export class ConnectivityState {
+	#online = $state(true);
+
+	constructor() {
+		if (!browser) {
+			return;
+		}
+
+		this.#online = navigator.onLine;
+		window.addEventListener('online', () => (this.#online = true));
+		window.addEventListener('offline', () => (this.#online = false));
+	}
+
+	get isOffline() {
+		return !this.#online;
+	}
+}
+
+const ConnectivityStateKey = Symbol('ConnectivityState');
+
+export function setConnectivityState() {
+	return setContext(ConnectivityStateKey, new ConnectivityState());
+}
+
+export function getConnectivityState() {
+	return getContext<ReturnType<typeof setConnectivityState>>(ConnectivityStateKey);
+}

--- a/src/routes/my/+layout.svelte
+++ b/src/routes/my/+layout.svelte
@@ -4,10 +4,12 @@
 	import ProfileMenu from '$components/ProfileMenu.svelte';
 	import Menu from '$components/Menu.svelte';
 	import Note from '$components/Note.svelte';
+	import OfflineIndicator from '$components/OfflineIndicator.svelte';
 	import Search from '$components/Search.svelte';
 	import logo from '$lib/images/notes-main.png';
 	import { tryFetch } from '$lib/browserFetch';
 	import { getBoardState } from '$lib/state/boardState.svelte';
+	import { setConnectivityState } from '$lib/state/connectivityState.svelte';
 	import { getToastMessages } from '$lib/state/toastMessages.svelte';
 	import { setFriendsState, getFriendsState } from '$lib/state/friendsState.svelte';
 	import { getUserState } from '$lib/state/userState.svelte';
@@ -27,6 +29,7 @@
 	const friendsState = getFriendsState();
 	const toastMessages = getToastMessages();
 	const userState = getUserState();
+	setConnectivityState();
 	const userId = data.userData?.id ?? '';
 
 	userState.setName(data.userData?.name ?? '');
@@ -103,13 +106,16 @@
 	>
 		<a href="/"><img src={logo} alt="Notes" class="size-14" /></a>
 		<Search />
-		{#if data.userData}
-			<ProfileMenu
-				userPicture={data.userData.picture!}
-				email={data.userData.email!}
-				name={userState.name}
-			/>
-		{/if}
+		<div class="flex items-center gap-3">
+			<OfflineIndicator />
+			{#if data.userData}
+				<ProfileMenu
+					userPicture={data.userData.picture!}
+					email={data.userData.email!}
+					name={userState.name}
+				/>
+			{/if}
+		</div>
 	</header>
 
 	<!-- Side menu -->

--- a/tests-offline/offline.test.ts
+++ b/tests-offline/offline.test.ts
@@ -3,6 +3,7 @@ import { expect, test, type Page } from '@playwright/test';
 const assetCachePrefix = 'assets-';
 const pageCachePrefix = 'pages-';
 const offlineHeading = "You're offline";
+const offlineIndicatorLabel = "You're offline. Changes will sync once you're back online.";
 const boardPath = '/my/board';
 const loginTimeoutMs = 15_000;
 // localCache.ts keys board snapshots as `board:<userId>`.
@@ -230,6 +231,26 @@ test('renders the authenticated board while offline', async ({ page, context }) 
 	// The cached document renders an empty board — the notes themselves only
 	// exist in IndexedDB — so matching content proves hydration actually ran.
 	expect(await notes.first().getAttribute('aria-label')).toBe(firstNoteLabel);
+});
+
+// Unlike the service-worker cases above, `online`/`offline` are live browser
+// events - no reload needed to see the header indicator react.
+test('shows and clears the header offline indicator as connectivity changes', async ({
+	page,
+	context
+}) => {
+	await page.goto('/');
+	await page.getByRole('link', { name: 'Login' }).click();
+	await login(page);
+
+	const indicator = page.getByLabel(offlineIndicatorLabel);
+	await expect(indicator).toBeHidden();
+
+	await context.setOffline(true);
+	await expect(indicator).toBeVisible();
+
+	await context.setOffline(false);
+	await expect(indicator).toBeHidden();
 });
 
 async function login(page: Page) {

--- a/tests-offline/offline.test.ts
+++ b/tests-offline/offline.test.ts
@@ -243,7 +243,7 @@ test('shows and clears the header offline indicator as connectivity changes', as
 	await page.getByRole('link', { name: 'Login' }).click();
 	await login(page);
 
-	const indicator = page.getByLabel(offlineIndicatorLabel);
+	const indicator = page.getByText(offlineIndicatorLabel);
 	await expect(indicator).toBeHidden();
 
 	await context.setOffline(true);


### PR DESCRIPTION
## Summary
- Adds `ConnectivityState` (`src/lib/state/connectivityState.svelte.ts`), tracking `navigator.onLine` plus `online`/`offline` window events
- Adds `OfflineIndicator.svelte`: an accessible `WifiOff` icon (warning colour, `role="status"`, reduced-motion-aware fade) shown in the header while offline
- Wires it into `src/routes/my/+layout.svelte` next to the profile menu

First half of #856 — the "syncing"/"failed replay" states get wired into this same component once the durable write queue (#855) lands, per that issue's own notes.

## Test plan
- [x] `pnpm check`, `pnpm lint`, `node docs/design-system/check-contrast.mjs` all pass
- [x] New Playwright test in `tests-offline/offline.test.ts` (`shows and clears the header offline indicator as connectivity changes`) — full offline suite passes (7/7)
- [x] Manually verified in a real browser (light + dark theme, mobile + desktop width): icon appears on `context.setOffline`/DevTools offline, clears when back online

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHLGgHgYvVPLDKMGVTHfnL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an offline status indicator to the application header.
  * Displays an accessible warning when connectivity is lost and updates automatically when connection is restored.
  * Supports smooth transitions, warning visuals, and reduced-motion preferences for a more comfortable experience.

* **Tests**
  * Added coverage confirming the indicator appears when offline and disappears after connectivity returns without requiring a page reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->